### PR TITLE
Fix default TTL

### DIFF
--- a/src/AccessToken.ts
+++ b/src/AccessToken.ts
@@ -2,7 +2,7 @@ import * as jwt from 'jsonwebtoken';
 import { ClaimGrants, VideoGrant } from './grants';
 
 // 6 hours
-const defaultTTL = 4 * 60 * 60;
+const defaultTTL = 6 * 60 * 60;
 
 export interface AccessTokenOptions {
   /**


### PR DESCRIPTION
The TTL's default value doesn't reflect what @davidzhao actually says in the comment above and the [README](https://github.com/livekit/server-sdk-js/blob/af51ec05affd5aafb253deb4af9825e76614bd4a/README.md?plain=1#L61):

> By default, the token expires after 6 hours.