### PR TITLE
Print error when creating a token inside a browser

### DIFF
--- a/src/AccessToken.ts
+++ b/src/AccessToken.ts
@@ -53,6 +53,11 @@ export class AccessToken {
     }
     if (!apiKey || !apiSecret) {
       throw Error('api-key and api-secret must be set');
+    } else if (typeof document !== 'undefined') {
+      // check against document rather than window because deno provides window
+      console.error("You should not include your API secret in your web client bundle.\n\n" +
+        "Your web client should request a token from your backend server which should then use " +
+        "the API secret to generate a token. See https://docs.livekit.io/docs/client-sdk/js");
     }
 
     this.apiKey = apiKey;

--- a/src/AccessToken.ts
+++ b/src/AccessToken.ts
@@ -55,9 +55,11 @@ export class AccessToken {
       throw Error('api-key and api-secret must be set');
     } else if (typeof document !== 'undefined') {
       // check against document rather than window because deno provides window
-      console.error("You should not include your API secret in your web client bundle.\n\n" +
-        "Your web client should request a token from your backend server which should then use " +
-        "the API secret to generate a token. See https://docs.livekit.io/docs/client-sdk/js");
+      console.error(
+        'You should not include your API secret in your web client bundle.\n\n' +
+          'Your web client should request a token from your backend server which should then use ' +
+          'the API secret to generate a token. See https://docs.livekit.io/client/connect/',
+      );
     }
 
     this.apiKey = apiKey;


### PR DESCRIPTION
## Overview

This change adds a debug log to the `AccessToken` constructor. If user code attempts to create an AccessToken inside a browser, we print the following warning with `console.error` but do not block the operation:

<img width="1213" alt="Screenshot 2023-03-27 at 2 30 49 PM" src="https://user-images.githubusercontent.com/13034/228071249-0bda975e-9ba9-4281-953c-f6574e0309e9.png">

## Testing

Tested with `ts-node` interactive console (warning not printed) and a fresh `create-next-app` app (warning printed to js console).