### PR TITLE
Export the correct TrackSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livekit-server-sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Server-side SDK for LiveKit",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,5 @@ export {
   ParticipantPermission,
   Room,
   TrackInfo,
-  TrackSource,
   TrackType,
 } from './proto/livekit_models';


### PR DESCRIPTION
`grants.ts` defines the correct TrackSource type to be used in VideoGrant. We were overriding that with the model export