### PR TITLE
Allow specifying permissions without spelling out all of the fields.

### DIFF
--- a/src/RoomServiceClient.ts
+++ b/src/RoomServiceClient.ts
@@ -1,10 +1,5 @@
-import {
-  DataPacket_Kind,
-  ParticipantInfo,
-  ParticipantPermission,
-  Room,
-  TrackInfo,
-} from './proto/livekit_models';
+import type { DataPacket_Kind, DeepPartial, Exact, TrackInfo } from './proto/livekit_models';
+import { ParticipantInfo, ParticipantPermission, Room } from './proto/livekit_models';
 import {
   CreateRoomRequest,
   DeleteRoomRequest,
@@ -223,20 +218,22 @@ export class RoomServiceClient extends ServiceBase {
    * @param permission optional, new permissions to assign to participant
    * @param name optional, new name for participant
    */
-  async updateParticipant(
+  async updateParticipant<I extends Exact<DeepPartial<ParticipantPermission>, I>>(
     room: string,
     identity: string,
     metadata?: string,
-    permission?: ParticipantPermission,
+    permission?: I,
     name?: string,
   ): Promise<ParticipantInfo> {
     const req: UpdateParticipantRequest = {
       room,
       identity,
       metadata: metadata || '',
-      permission,
       name: name || '',
     };
+    if (permission) {
+      req.permission = ParticipantPermission.fromPartial(permission);
+    }
     const data = await this.rpc.request(
       svc,
       'UpdateParticipant',

--- a/src/RoomServiceClient.ts
+++ b/src/RoomServiceClient.ts
@@ -1,4 +1,4 @@
-import type { DataPacket_Kind, DeepPartial, Exact, TrackInfo } from './proto/livekit_models';
+import type { DataPacket_Kind, DeepPartial, TrackInfo } from './proto/livekit_models';
 import { ParticipantInfo, ParticipantPermission, Room } from './proto/livekit_models';
 import {
   CreateRoomRequest,
@@ -218,11 +218,11 @@ export class RoomServiceClient extends ServiceBase {
    * @param permission optional, new permissions to assign to participant
    * @param name optional, new name for participant
    */
-  async updateParticipant<I extends Exact<DeepPartial<ParticipantPermission>, I>>(
+  async updateParticipant(
     room: string,
     identity: string,
     metadata?: string,
-    permission?: I,
+    permission?: DeepPartial<ParticipantPermission>,
     name?: string,
   ): Promise<ParticipantInfo> {
     const req: UpdateParticipantRequest = {

--- a/src/proto/google/protobuf/timestamp.ts
+++ b/src/proto/google/protobuf/timestamp.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
-export const protobufPackage = 'google.protobuf';
+export const protobufPackage = "google.protobuf";
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local
@@ -55,7 +55,6 @@ export const protobufPackage = 'google.protobuf';
  *     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
  *         .setNanos((int) ((millis % 1000) * 1000000)).build();
  *
- *
  * Example 5: Compute Timestamp from Java `Instant.now()`.
  *
  *     Instant now = Instant.now();
@@ -63,7 +62,6 @@ export const protobufPackage = 'google.protobuf';
  *     Timestamp timestamp =
  *         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
  *             .setNanos(now.getNano()).build();
- *
  *
  * Example 6: Compute Timestamp from current time in Python.
  *
@@ -94,7 +92,7 @@ export const protobufPackage = 'google.protobuf';
  * [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
  * the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
  * the Joda Time's [`ISODateTimeFormat.dateTime()`](
- * http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+ * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
  * ) to obtain a formatter capable of generating timestamps in this format.
  */
 export interface Timestamp {
@@ -175,33 +173,35 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
 })();
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }

--- a/src/proto/livekit_egress.ts
+++ b/src/proto/livekit_egress.ts
@@ -1,16 +1,16 @@
 /* eslint-disable */
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import {
   AudioCodec,
-  VideoCodec,
   audioCodecFromJSON,
-  videoCodecFromJSON,
   audioCodecToJSON,
+  VideoCodec,
+  videoCodecFromJSON,
   videoCodecToJSON,
-} from './livekit_models';
+} from "./livekit_models";
 
-export const protobufPackage = 'livekit';
+export const protobufPackage = "livekit";
 
 export enum EncodedFileType {
   /** DEFAULT_FILETYPE - file type chosen based on codecs */
@@ -23,16 +23,16 @@ export enum EncodedFileType {
 export function encodedFileTypeFromJSON(object: any): EncodedFileType {
   switch (object) {
     case 0:
-    case 'DEFAULT_FILETYPE':
+    case "DEFAULT_FILETYPE":
       return EncodedFileType.DEFAULT_FILETYPE;
     case 1:
-    case 'MP4':
+    case "MP4":
       return EncodedFileType.MP4;
     case 2:
-    case 'OGG':
+    case "OGG":
       return EncodedFileType.OGG;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return EncodedFileType.UNRECOGNIZED;
   }
@@ -41,13 +41,14 @@ export function encodedFileTypeFromJSON(object: any): EncodedFileType {
 export function encodedFileTypeToJSON(object: EncodedFileType): string {
   switch (object) {
     case EncodedFileType.DEFAULT_FILETYPE:
-      return 'DEFAULT_FILETYPE';
+      return "DEFAULT_FILETYPE";
     case EncodedFileType.MP4:
-      return 'MP4';
+      return "MP4";
     case EncodedFileType.OGG:
-      return 'OGG';
+      return "OGG";
+    case EncodedFileType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -60,13 +61,13 @@ export enum SegmentedFileProtocol {
 export function segmentedFileProtocolFromJSON(object: any): SegmentedFileProtocol {
   switch (object) {
     case 0:
-    case 'DEFAULT_SEGMENTED_FILE_PROTOCOL':
+    case "DEFAULT_SEGMENTED_FILE_PROTOCOL":
       return SegmentedFileProtocol.DEFAULT_SEGMENTED_FILE_PROTOCOL;
     case 1:
-    case 'HLS_PROTOCOL':
+    case "HLS_PROTOCOL":
       return SegmentedFileProtocol.HLS_PROTOCOL;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return SegmentedFileProtocol.UNRECOGNIZED;
   }
@@ -75,11 +76,12 @@ export function segmentedFileProtocolFromJSON(object: any): SegmentedFileProtoco
 export function segmentedFileProtocolToJSON(object: SegmentedFileProtocol): string {
   switch (object) {
     case SegmentedFileProtocol.DEFAULT_SEGMENTED_FILE_PROTOCOL:
-      return 'DEFAULT_SEGMENTED_FILE_PROTOCOL';
+      return "DEFAULT_SEGMENTED_FILE_PROTOCOL";
     case SegmentedFileProtocol.HLS_PROTOCOL:
-      return 'HLS_PROTOCOL';
+      return "HLS_PROTOCOL";
+    case SegmentedFileProtocol.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -92,13 +94,13 @@ export enum SegmentedFileSuffix {
 export function segmentedFileSuffixFromJSON(object: any): SegmentedFileSuffix {
   switch (object) {
     case 0:
-    case 'INDEX':
+    case "INDEX":
       return SegmentedFileSuffix.INDEX;
     case 1:
-    case 'TIMESTAMP':
+    case "TIMESTAMP":
       return SegmentedFileSuffix.TIMESTAMP;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return SegmentedFileSuffix.UNRECOGNIZED;
   }
@@ -107,11 +109,12 @@ export function segmentedFileSuffixFromJSON(object: any): SegmentedFileSuffix {
 export function segmentedFileSuffixToJSON(object: SegmentedFileSuffix): string {
   switch (object) {
     case SegmentedFileSuffix.INDEX:
-      return 'INDEX';
+      return "INDEX";
     case SegmentedFileSuffix.TIMESTAMP:
-      return 'TIMESTAMP';
+      return "TIMESTAMP";
+    case SegmentedFileSuffix.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -125,13 +128,13 @@ export enum StreamProtocol {
 export function streamProtocolFromJSON(object: any): StreamProtocol {
   switch (object) {
     case 0:
-    case 'DEFAULT_PROTOCOL':
+    case "DEFAULT_PROTOCOL":
       return StreamProtocol.DEFAULT_PROTOCOL;
     case 1:
-    case 'RTMP':
+    case "RTMP":
       return StreamProtocol.RTMP;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return StreamProtocol.UNRECOGNIZED;
   }
@@ -140,11 +143,12 @@ export function streamProtocolFromJSON(object: any): StreamProtocol {
 export function streamProtocolToJSON(object: StreamProtocol): string {
   switch (object) {
     case StreamProtocol.DEFAULT_PROTOCOL:
-      return 'DEFAULT_PROTOCOL';
+      return "DEFAULT_PROTOCOL";
     case StreamProtocol.RTMP:
-      return 'RTMP';
+      return "RTMP";
+    case StreamProtocol.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -171,31 +175,31 @@ export enum EncodingOptionsPreset {
 export function encodingOptionsPresetFromJSON(object: any): EncodingOptionsPreset {
   switch (object) {
     case 0:
-    case 'H264_720P_30':
+    case "H264_720P_30":
       return EncodingOptionsPreset.H264_720P_30;
     case 1:
-    case 'H264_720P_60':
+    case "H264_720P_60":
       return EncodingOptionsPreset.H264_720P_60;
     case 2:
-    case 'H264_1080P_30':
+    case "H264_1080P_30":
       return EncodingOptionsPreset.H264_1080P_30;
     case 3:
-    case 'H264_1080P_60':
+    case "H264_1080P_60":
       return EncodingOptionsPreset.H264_1080P_60;
     case 4:
-    case 'PORTRAIT_H264_720P_30':
+    case "PORTRAIT_H264_720P_30":
       return EncodingOptionsPreset.PORTRAIT_H264_720P_30;
     case 5:
-    case 'PORTRAIT_H264_720P_60':
+    case "PORTRAIT_H264_720P_60":
       return EncodingOptionsPreset.PORTRAIT_H264_720P_60;
     case 6:
-    case 'PORTRAIT_H264_1080P_30':
+    case "PORTRAIT_H264_1080P_30":
       return EncodingOptionsPreset.PORTRAIT_H264_1080P_30;
     case 7:
-    case 'PORTRAIT_H264_1080P_60':
+    case "PORTRAIT_H264_1080P_60":
       return EncodingOptionsPreset.PORTRAIT_H264_1080P_60;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return EncodingOptionsPreset.UNRECOGNIZED;
   }
@@ -204,23 +208,24 @@ export function encodingOptionsPresetFromJSON(object: any): EncodingOptionsPrese
 export function encodingOptionsPresetToJSON(object: EncodingOptionsPreset): string {
   switch (object) {
     case EncodingOptionsPreset.H264_720P_30:
-      return 'H264_720P_30';
+      return "H264_720P_30";
     case EncodingOptionsPreset.H264_720P_60:
-      return 'H264_720P_60';
+      return "H264_720P_60";
     case EncodingOptionsPreset.H264_1080P_30:
-      return 'H264_1080P_30';
+      return "H264_1080P_30";
     case EncodingOptionsPreset.H264_1080P_60:
-      return 'H264_1080P_60';
+      return "H264_1080P_60";
     case EncodingOptionsPreset.PORTRAIT_H264_720P_30:
-      return 'PORTRAIT_H264_720P_30';
+      return "PORTRAIT_H264_720P_30";
     case EncodingOptionsPreset.PORTRAIT_H264_720P_60:
-      return 'PORTRAIT_H264_720P_60';
+      return "PORTRAIT_H264_720P_60";
     case EncodingOptionsPreset.PORTRAIT_H264_1080P_30:
-      return 'PORTRAIT_H264_1080P_30';
+      return "PORTRAIT_H264_1080P_30";
     case EncodingOptionsPreset.PORTRAIT_H264_1080P_60:
-      return 'PORTRAIT_H264_1080P_60';
+      return "PORTRAIT_H264_1080P_60";
+    case EncodingOptionsPreset.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -238,28 +243,28 @@ export enum EgressStatus {
 export function egressStatusFromJSON(object: any): EgressStatus {
   switch (object) {
     case 0:
-    case 'EGRESS_STARTING':
+    case "EGRESS_STARTING":
       return EgressStatus.EGRESS_STARTING;
     case 1:
-    case 'EGRESS_ACTIVE':
+    case "EGRESS_ACTIVE":
       return EgressStatus.EGRESS_ACTIVE;
     case 2:
-    case 'EGRESS_ENDING':
+    case "EGRESS_ENDING":
       return EgressStatus.EGRESS_ENDING;
     case 3:
-    case 'EGRESS_COMPLETE':
+    case "EGRESS_COMPLETE":
       return EgressStatus.EGRESS_COMPLETE;
     case 4:
-    case 'EGRESS_FAILED':
+    case "EGRESS_FAILED":
       return EgressStatus.EGRESS_FAILED;
     case 5:
-    case 'EGRESS_ABORTED':
+    case "EGRESS_ABORTED":
       return EgressStatus.EGRESS_ABORTED;
     case 6:
-    case 'EGRESS_LIMIT_REACHED':
+    case "EGRESS_LIMIT_REACHED":
       return EgressStatus.EGRESS_LIMIT_REACHED;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return EgressStatus.UNRECOGNIZED;
   }
@@ -268,21 +273,22 @@ export function egressStatusFromJSON(object: any): EgressStatus {
 export function egressStatusToJSON(object: EgressStatus): string {
   switch (object) {
     case EgressStatus.EGRESS_STARTING:
-      return 'EGRESS_STARTING';
+      return "EGRESS_STARTING";
     case EgressStatus.EGRESS_ACTIVE:
-      return 'EGRESS_ACTIVE';
+      return "EGRESS_ACTIVE";
     case EgressStatus.EGRESS_ENDING:
-      return 'EGRESS_ENDING';
+      return "EGRESS_ENDING";
     case EgressStatus.EGRESS_COMPLETE:
-      return 'EGRESS_COMPLETE';
+      return "EGRESS_COMPLETE";
     case EgressStatus.EGRESS_FAILED:
-      return 'EGRESS_FAILED';
+      return "EGRESS_FAILED";
     case EgressStatus.EGRESS_ABORTED:
-      return 'EGRESS_ABORTED';
+      return "EGRESS_ABORTED";
     case EgressStatus.EGRESS_LIMIT_REACHED:
-      return 'EGRESS_LIMIT_REACHED';
+      return "EGRESS_LIMIT_REACHED";
+    case EgressStatus.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -299,13 +305,21 @@ export interface RoomCompositeEgressRequest {
   /** template base url (default https://recorder.livekit.io) */
   customBaseUrl?: string;
   /** @deprecated */
-  file?: EncodedFileOutput | undefined;
+  file?:
+    | EncodedFileOutput
+    | undefined;
   /** @deprecated */
-  stream?: StreamOutput | undefined;
+  stream?:
+    | StreamOutput
+    | undefined;
   /** @deprecated */
-  segments?: SegmentedFileOutput | undefined;
+  segments?:
+    | SegmentedFileOutput
+    | undefined;
   /** (default H264_720P_30) */
-  preset?: EncodingOptionsPreset | undefined;
+  preset?:
+    | EncodingOptionsPreset
+    | undefined;
   /** (optional) */
   advanced?: EncodingOptions | undefined;
   fileOutputs?: EncodedFileOutput[];
@@ -320,9 +334,13 @@ export interface WebEgressRequest {
   videoOnly?: boolean;
   awaitStartSignal?: boolean;
   /** @deprecated */
-  file?: EncodedFileOutput | undefined;
+  file?:
+    | EncodedFileOutput
+    | undefined;
   /** @deprecated */
-  stream?: StreamOutput | undefined;
+  stream?:
+    | StreamOutput
+    | undefined;
   /** @deprecated */
   segments?: SegmentedFileOutput | undefined;
   preset?: EncodingOptionsPreset | undefined;
@@ -341,13 +359,21 @@ export interface TrackCompositeEgressRequest {
   /** (optional) */
   videoTrackId?: string;
   /** @deprecated */
-  file?: EncodedFileOutput | undefined;
+  file?:
+    | EncodedFileOutput
+    | undefined;
   /** @deprecated */
-  stream?: StreamOutput | undefined;
+  stream?:
+    | StreamOutput
+    | undefined;
   /** @deprecated */
-  segments?: SegmentedFileOutput | undefined;
+  segments?:
+    | SegmentedFileOutput
+    | undefined;
   /** (default H264_720P_30) */
-  preset?: EncodingOptionsPreset | undefined;
+  preset?:
+    | EncodingOptionsPreset
+    | undefined;
   /** (optional) */
   advanced?: EncodingOptions | undefined;
   fileOutputs?: EncodedFileOutput[];
@@ -509,15 +535,22 @@ export interface EgressInfo {
   status?: EgressStatus;
   startedAt?: number;
   endedAt?: number;
+  updatedAt?: number;
   error?: string;
   roomComposite?: RoomCompositeEgressRequest | undefined;
   trackComposite?: TrackCompositeEgressRequest | undefined;
   track?: TrackEgressRequest | undefined;
-  web?: WebEgressRequest | undefined;
+  web?:
+    | WebEgressRequest
+    | undefined;
   /** @deprecated */
-  stream?: StreamInfoList | undefined;
+  stream?:
+    | StreamInfoList
+    | undefined;
   /** @deprecated */
-  file?: FileInfo | undefined;
+  file?:
+    | FileInfo
+    | undefined;
   /** @deprecated */
   segments?: SegmentsInfo | undefined;
   streamResults?: StreamInfo[];
@@ -549,16 +582,16 @@ export enum StreamInfo_Status {
 export function streamInfo_StatusFromJSON(object: any): StreamInfo_Status {
   switch (object) {
     case 0:
-    case 'ACTIVE':
+    case "ACTIVE":
       return StreamInfo_Status.ACTIVE;
     case 1:
-    case 'FINISHED':
+    case "FINISHED":
       return StreamInfo_Status.FINISHED;
     case 2:
-    case 'FAILED':
+    case "FAILED":
       return StreamInfo_Status.FAILED;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return StreamInfo_Status.UNRECOGNIZED;
   }
@@ -567,13 +600,14 @@ export function streamInfo_StatusFromJSON(object: any): StreamInfo_Status {
 export function streamInfo_StatusToJSON(object: StreamInfo_Status): string {
   switch (object) {
     case StreamInfo_Status.ACTIVE:
-      return 'ACTIVE';
+      return "ACTIVE";
     case StreamInfo_Status.FINISHED:
-      return 'FINISHED';
+      return "FINISHED";
     case StreamInfo_Status.FAILED:
-      return 'FAILED';
+      return "FAILED";
+    case StreamInfo_Status.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -608,11 +642,11 @@ export interface AutoTrackEgress {
 
 function createBaseRoomCompositeEgressRequest(): RoomCompositeEgressRequest {
   return {
-    roomName: '',
-    layout: '',
+    roomName: "",
+    layout: "",
     audioOnly: false,
     videoOnly: false,
-    customBaseUrl: '',
+    customBaseUrl: "",
     file: undefined,
     stream: undefined,
     segments: undefined,
@@ -625,14 +659,11 @@ function createBaseRoomCompositeEgressRequest(): RoomCompositeEgressRequest {
 }
 
 export const RoomCompositeEgressRequest = {
-  encode(
-    message: RoomCompositeEgressRequest,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
-    if (message.roomName !== undefined && message.roomName !== '') {
+  encode(message: RoomCompositeEgressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(10).string(message.roomName);
     }
-    if (message.layout !== undefined && message.layout !== '') {
+    if (message.layout !== undefined && message.layout !== "") {
       writer.uint32(18).string(message.layout);
     }
     if (message.audioOnly === true) {
@@ -641,7 +672,7 @@ export const RoomCompositeEgressRequest = {
     if (message.videoOnly === true) {
       writer.uint32(32).bool(message.videoOnly);
     }
-    if (message.customBaseUrl !== undefined && message.customBaseUrl !== '') {
+    if (message.customBaseUrl !== undefined && message.customBaseUrl !== "") {
       writer.uint32(42).string(message.customBaseUrl);
     }
     if (message.file !== undefined) {
@@ -733,11 +764,11 @@ export const RoomCompositeEgressRequest = {
 
   fromJSON(object: any): RoomCompositeEgressRequest {
     return {
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      layout: isSet(object.layout) ? String(object.layout) : '',
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      layout: isSet(object.layout) ? String(object.layout) : "",
       audioOnly: isSet(object.audioOnly) ? Boolean(object.audioOnly) : false,
       videoOnly: isSet(object.videoOnly) ? Boolean(object.videoOnly) : false,
-      customBaseUrl: isSet(object.customBaseUrl) ? String(object.customBaseUrl) : '',
+      customBaseUrl: isSet(object.customBaseUrl) ? String(object.customBaseUrl) : "",
       file: isSet(object.file) ? EncodedFileOutput.fromJSON(object.file) : undefined,
       stream: isSet(object.stream) ? StreamOutput.fromJSON(object.stream) : undefined,
       segments: isSet(object.segments) ? SegmentedFileOutput.fromJSON(object.segments) : undefined,
@@ -762,78 +793,62 @@ export const RoomCompositeEgressRequest = {
     message.audioOnly !== undefined && (obj.audioOnly = message.audioOnly);
     message.videoOnly !== undefined && (obj.videoOnly = message.videoOnly);
     message.customBaseUrl !== undefined && (obj.customBaseUrl = message.customBaseUrl);
-    message.file !== undefined &&
-      (obj.file = message.file ? EncodedFileOutput.toJSON(message.file) : undefined);
-    message.stream !== undefined &&
-      (obj.stream = message.stream ? StreamOutput.toJSON(message.stream) : undefined);
+    message.file !== undefined && (obj.file = message.file ? EncodedFileOutput.toJSON(message.file) : undefined);
+    message.stream !== undefined && (obj.stream = message.stream ? StreamOutput.toJSON(message.stream) : undefined);
     message.segments !== undefined &&
       (obj.segments = message.segments ? SegmentedFileOutput.toJSON(message.segments) : undefined);
     message.preset !== undefined &&
-      (obj.preset =
-        message.preset !== undefined ? encodingOptionsPresetToJSON(message.preset) : undefined);
+      (obj.preset = message.preset !== undefined ? encodingOptionsPresetToJSON(message.preset) : undefined);
     message.advanced !== undefined &&
       (obj.advanced = message.advanced ? EncodingOptions.toJSON(message.advanced) : undefined);
     if (message.fileOutputs) {
-      obj.fileOutputs = message.fileOutputs.map((e) =>
-        e ? EncodedFileOutput.toJSON(e) : undefined,
-      );
+      obj.fileOutputs = message.fileOutputs.map((e) => e ? EncodedFileOutput.toJSON(e) : undefined);
     } else {
       obj.fileOutputs = [];
     }
     if (message.streamOutputs) {
-      obj.streamOutputs = message.streamOutputs.map((e) =>
-        e ? StreamOutput.toJSON(e) : undefined,
-      );
+      obj.streamOutputs = message.streamOutputs.map((e) => e ? StreamOutput.toJSON(e) : undefined);
     } else {
       obj.streamOutputs = [];
     }
     if (message.segmentOutputs) {
-      obj.segmentOutputs = message.segmentOutputs.map((e) =>
-        e ? SegmentedFileOutput.toJSON(e) : undefined,
-      );
+      obj.segmentOutputs = message.segmentOutputs.map((e) => e ? SegmentedFileOutput.toJSON(e) : undefined);
     } else {
       obj.segmentOutputs = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<RoomCompositeEgressRequest>, I>>(
-    object: I,
-  ): RoomCompositeEgressRequest {
+  fromPartial<I extends Exact<DeepPartial<RoomCompositeEgressRequest>, I>>(object: I): RoomCompositeEgressRequest {
     const message = createBaseRoomCompositeEgressRequest();
-    message.roomName = object.roomName ?? '';
-    message.layout = object.layout ?? '';
+    message.roomName = object.roomName ?? "";
+    message.layout = object.layout ?? "";
     message.audioOnly = object.audioOnly ?? false;
     message.videoOnly = object.videoOnly ?? false;
-    message.customBaseUrl = object.customBaseUrl ?? '';
-    message.file =
-      object.file !== undefined && object.file !== null
-        ? EncodedFileOutput.fromPartial(object.file)
-        : undefined;
-    message.stream =
-      object.stream !== undefined && object.stream !== null
-        ? StreamOutput.fromPartial(object.stream)
-        : undefined;
-    message.segments =
-      object.segments !== undefined && object.segments !== null
-        ? SegmentedFileOutput.fromPartial(object.segments)
-        : undefined;
+    message.customBaseUrl = object.customBaseUrl ?? "";
+    message.file = (object.file !== undefined && object.file !== null)
+      ? EncodedFileOutput.fromPartial(object.file)
+      : undefined;
+    message.stream = (object.stream !== undefined && object.stream !== null)
+      ? StreamOutput.fromPartial(object.stream)
+      : undefined;
+    message.segments = (object.segments !== undefined && object.segments !== null)
+      ? SegmentedFileOutput.fromPartial(object.segments)
+      : undefined;
     message.preset = object.preset ?? undefined;
-    message.advanced =
-      object.advanced !== undefined && object.advanced !== null
-        ? EncodingOptions.fromPartial(object.advanced)
-        : undefined;
+    message.advanced = (object.advanced !== undefined && object.advanced !== null)
+      ? EncodingOptions.fromPartial(object.advanced)
+      : undefined;
     message.fileOutputs = object.fileOutputs?.map((e) => EncodedFileOutput.fromPartial(e)) || [];
     message.streamOutputs = object.streamOutputs?.map((e) => StreamOutput.fromPartial(e)) || [];
-    message.segmentOutputs =
-      object.segmentOutputs?.map((e) => SegmentedFileOutput.fromPartial(e)) || [];
+    message.segmentOutputs = object.segmentOutputs?.map((e) => SegmentedFileOutput.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseWebEgressRequest(): WebEgressRequest {
   return {
-    url: '',
+    url: "",
     audioOnly: false,
     videoOnly: false,
     awaitStartSignal: false,
@@ -850,7 +865,7 @@ function createBaseWebEgressRequest(): WebEgressRequest {
 
 export const WebEgressRequest = {
   encode(message: WebEgressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.url !== undefined && message.url !== '') {
+    if (message.url !== undefined && message.url !== "") {
       writer.uint32(10).string(message.url);
     }
     if (message.audioOnly === true) {
@@ -948,7 +963,7 @@ export const WebEgressRequest = {
 
   fromJSON(object: any): WebEgressRequest {
     return {
-      url: isSet(object.url) ? String(object.url) : '',
+      url: isSet(object.url) ? String(object.url) : "",
       audioOnly: isSet(object.audioOnly) ? Boolean(object.audioOnly) : false,
       videoOnly: isSet(object.videoOnly) ? Boolean(object.videoOnly) : false,
       awaitStartSignal: isSet(object.awaitStartSignal) ? Boolean(object.awaitStartSignal) : false,
@@ -975,35 +990,26 @@ export const WebEgressRequest = {
     message.audioOnly !== undefined && (obj.audioOnly = message.audioOnly);
     message.videoOnly !== undefined && (obj.videoOnly = message.videoOnly);
     message.awaitStartSignal !== undefined && (obj.awaitStartSignal = message.awaitStartSignal);
-    message.file !== undefined &&
-      (obj.file = message.file ? EncodedFileOutput.toJSON(message.file) : undefined);
-    message.stream !== undefined &&
-      (obj.stream = message.stream ? StreamOutput.toJSON(message.stream) : undefined);
+    message.file !== undefined && (obj.file = message.file ? EncodedFileOutput.toJSON(message.file) : undefined);
+    message.stream !== undefined && (obj.stream = message.stream ? StreamOutput.toJSON(message.stream) : undefined);
     message.segments !== undefined &&
       (obj.segments = message.segments ? SegmentedFileOutput.toJSON(message.segments) : undefined);
     message.preset !== undefined &&
-      (obj.preset =
-        message.preset !== undefined ? encodingOptionsPresetToJSON(message.preset) : undefined);
+      (obj.preset = message.preset !== undefined ? encodingOptionsPresetToJSON(message.preset) : undefined);
     message.advanced !== undefined &&
       (obj.advanced = message.advanced ? EncodingOptions.toJSON(message.advanced) : undefined);
     if (message.fileOutputs) {
-      obj.fileOutputs = message.fileOutputs.map((e) =>
-        e ? EncodedFileOutput.toJSON(e) : undefined,
-      );
+      obj.fileOutputs = message.fileOutputs.map((e) => e ? EncodedFileOutput.toJSON(e) : undefined);
     } else {
       obj.fileOutputs = [];
     }
     if (message.streamOutputs) {
-      obj.streamOutputs = message.streamOutputs.map((e) =>
-        e ? StreamOutput.toJSON(e) : undefined,
-      );
+      obj.streamOutputs = message.streamOutputs.map((e) => e ? StreamOutput.toJSON(e) : undefined);
     } else {
       obj.streamOutputs = [];
     }
     if (message.segmentOutputs) {
-      obj.segmentOutputs = message.segmentOutputs.map((e) =>
-        e ? SegmentedFileOutput.toJSON(e) : undefined,
-      );
+      obj.segmentOutputs = message.segmentOutputs.map((e) => e ? SegmentedFileOutput.toJSON(e) : undefined);
     } else {
       obj.segmentOutputs = [];
     }
@@ -1012,40 +1018,35 @@ export const WebEgressRequest = {
 
   fromPartial<I extends Exact<DeepPartial<WebEgressRequest>, I>>(object: I): WebEgressRequest {
     const message = createBaseWebEgressRequest();
-    message.url = object.url ?? '';
+    message.url = object.url ?? "";
     message.audioOnly = object.audioOnly ?? false;
     message.videoOnly = object.videoOnly ?? false;
     message.awaitStartSignal = object.awaitStartSignal ?? false;
-    message.file =
-      object.file !== undefined && object.file !== null
-        ? EncodedFileOutput.fromPartial(object.file)
-        : undefined;
-    message.stream =
-      object.stream !== undefined && object.stream !== null
-        ? StreamOutput.fromPartial(object.stream)
-        : undefined;
-    message.segments =
-      object.segments !== undefined && object.segments !== null
-        ? SegmentedFileOutput.fromPartial(object.segments)
-        : undefined;
+    message.file = (object.file !== undefined && object.file !== null)
+      ? EncodedFileOutput.fromPartial(object.file)
+      : undefined;
+    message.stream = (object.stream !== undefined && object.stream !== null)
+      ? StreamOutput.fromPartial(object.stream)
+      : undefined;
+    message.segments = (object.segments !== undefined && object.segments !== null)
+      ? SegmentedFileOutput.fromPartial(object.segments)
+      : undefined;
     message.preset = object.preset ?? undefined;
-    message.advanced =
-      object.advanced !== undefined && object.advanced !== null
-        ? EncodingOptions.fromPartial(object.advanced)
-        : undefined;
+    message.advanced = (object.advanced !== undefined && object.advanced !== null)
+      ? EncodingOptions.fromPartial(object.advanced)
+      : undefined;
     message.fileOutputs = object.fileOutputs?.map((e) => EncodedFileOutput.fromPartial(e)) || [];
     message.streamOutputs = object.streamOutputs?.map((e) => StreamOutput.fromPartial(e)) || [];
-    message.segmentOutputs =
-      object.segmentOutputs?.map((e) => SegmentedFileOutput.fromPartial(e)) || [];
+    message.segmentOutputs = object.segmentOutputs?.map((e) => SegmentedFileOutput.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseTrackCompositeEgressRequest(): TrackCompositeEgressRequest {
   return {
-    roomName: '',
-    audioTrackId: '',
-    videoTrackId: '',
+    roomName: "",
+    audioTrackId: "",
+    videoTrackId: "",
     file: undefined,
     stream: undefined,
     segments: undefined,
@@ -1058,17 +1059,14 @@ function createBaseTrackCompositeEgressRequest(): TrackCompositeEgressRequest {
 }
 
 export const TrackCompositeEgressRequest = {
-  encode(
-    message: TrackCompositeEgressRequest,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
-    if (message.roomName !== undefined && message.roomName !== '') {
+  encode(message: TrackCompositeEgressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(10).string(message.roomName);
     }
-    if (message.audioTrackId !== undefined && message.audioTrackId !== '') {
+    if (message.audioTrackId !== undefined && message.audioTrackId !== "") {
       writer.uint32(18).string(message.audioTrackId);
     }
-    if (message.videoTrackId !== undefined && message.videoTrackId !== '') {
+    if (message.videoTrackId !== undefined && message.videoTrackId !== "") {
       writer.uint32(26).string(message.videoTrackId);
     }
     if (message.file !== undefined) {
@@ -1154,9 +1152,9 @@ export const TrackCompositeEgressRequest = {
 
   fromJSON(object: any): TrackCompositeEgressRequest {
     return {
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      audioTrackId: isSet(object.audioTrackId) ? String(object.audioTrackId) : '',
-      videoTrackId: isSet(object.videoTrackId) ? String(object.videoTrackId) : '',
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      audioTrackId: isSet(object.audioTrackId) ? String(object.audioTrackId) : "",
+      videoTrackId: isSet(object.videoTrackId) ? String(object.videoTrackId) : "",
       file: isSet(object.file) ? EncodedFileOutput.fromJSON(object.file) : undefined,
       stream: isSet(object.stream) ? StreamOutput.fromJSON(object.stream) : undefined,
       segments: isSet(object.segments) ? SegmentedFileOutput.fromJSON(object.segments) : undefined,
@@ -1179,83 +1177,67 @@ export const TrackCompositeEgressRequest = {
     message.roomName !== undefined && (obj.roomName = message.roomName);
     message.audioTrackId !== undefined && (obj.audioTrackId = message.audioTrackId);
     message.videoTrackId !== undefined && (obj.videoTrackId = message.videoTrackId);
-    message.file !== undefined &&
-      (obj.file = message.file ? EncodedFileOutput.toJSON(message.file) : undefined);
-    message.stream !== undefined &&
-      (obj.stream = message.stream ? StreamOutput.toJSON(message.stream) : undefined);
+    message.file !== undefined && (obj.file = message.file ? EncodedFileOutput.toJSON(message.file) : undefined);
+    message.stream !== undefined && (obj.stream = message.stream ? StreamOutput.toJSON(message.stream) : undefined);
     message.segments !== undefined &&
       (obj.segments = message.segments ? SegmentedFileOutput.toJSON(message.segments) : undefined);
     message.preset !== undefined &&
-      (obj.preset =
-        message.preset !== undefined ? encodingOptionsPresetToJSON(message.preset) : undefined);
+      (obj.preset = message.preset !== undefined ? encodingOptionsPresetToJSON(message.preset) : undefined);
     message.advanced !== undefined &&
       (obj.advanced = message.advanced ? EncodingOptions.toJSON(message.advanced) : undefined);
     if (message.fileOutputs) {
-      obj.fileOutputs = message.fileOutputs.map((e) =>
-        e ? EncodedFileOutput.toJSON(e) : undefined,
-      );
+      obj.fileOutputs = message.fileOutputs.map((e) => e ? EncodedFileOutput.toJSON(e) : undefined);
     } else {
       obj.fileOutputs = [];
     }
     if (message.streamOutputs) {
-      obj.streamOutputs = message.streamOutputs.map((e) =>
-        e ? StreamOutput.toJSON(e) : undefined,
-      );
+      obj.streamOutputs = message.streamOutputs.map((e) => e ? StreamOutput.toJSON(e) : undefined);
     } else {
       obj.streamOutputs = [];
     }
     if (message.segmentOutputs) {
-      obj.segmentOutputs = message.segmentOutputs.map((e) =>
-        e ? SegmentedFileOutput.toJSON(e) : undefined,
-      );
+      obj.segmentOutputs = message.segmentOutputs.map((e) => e ? SegmentedFileOutput.toJSON(e) : undefined);
     } else {
       obj.segmentOutputs = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<TrackCompositeEgressRequest>, I>>(
-    object: I,
-  ): TrackCompositeEgressRequest {
+  fromPartial<I extends Exact<DeepPartial<TrackCompositeEgressRequest>, I>>(object: I): TrackCompositeEgressRequest {
     const message = createBaseTrackCompositeEgressRequest();
-    message.roomName = object.roomName ?? '';
-    message.audioTrackId = object.audioTrackId ?? '';
-    message.videoTrackId = object.videoTrackId ?? '';
-    message.file =
-      object.file !== undefined && object.file !== null
-        ? EncodedFileOutput.fromPartial(object.file)
-        : undefined;
-    message.stream =
-      object.stream !== undefined && object.stream !== null
-        ? StreamOutput.fromPartial(object.stream)
-        : undefined;
-    message.segments =
-      object.segments !== undefined && object.segments !== null
-        ? SegmentedFileOutput.fromPartial(object.segments)
-        : undefined;
+    message.roomName = object.roomName ?? "";
+    message.audioTrackId = object.audioTrackId ?? "";
+    message.videoTrackId = object.videoTrackId ?? "";
+    message.file = (object.file !== undefined && object.file !== null)
+      ? EncodedFileOutput.fromPartial(object.file)
+      : undefined;
+    message.stream = (object.stream !== undefined && object.stream !== null)
+      ? StreamOutput.fromPartial(object.stream)
+      : undefined;
+    message.segments = (object.segments !== undefined && object.segments !== null)
+      ? SegmentedFileOutput.fromPartial(object.segments)
+      : undefined;
     message.preset = object.preset ?? undefined;
-    message.advanced =
-      object.advanced !== undefined && object.advanced !== null
-        ? EncodingOptions.fromPartial(object.advanced)
-        : undefined;
+    message.advanced = (object.advanced !== undefined && object.advanced !== null)
+      ? EncodingOptions.fromPartial(object.advanced)
+      : undefined;
     message.fileOutputs = object.fileOutputs?.map((e) => EncodedFileOutput.fromPartial(e)) || [];
     message.streamOutputs = object.streamOutputs?.map((e) => StreamOutput.fromPartial(e)) || [];
-    message.segmentOutputs =
-      object.segmentOutputs?.map((e) => SegmentedFileOutput.fromPartial(e)) || [];
+    message.segmentOutputs = object.segmentOutputs?.map((e) => SegmentedFileOutput.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseTrackEgressRequest(): TrackEgressRequest {
-  return { roomName: '', trackId: '', file: undefined, websocketUrl: undefined };
+  return { roomName: "", trackId: "", file: undefined, websocketUrl: undefined };
 }
 
 export const TrackEgressRequest = {
   encode(message: TrackEgressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(10).string(message.roomName);
     }
-    if (message.trackId !== undefined && message.trackId !== '') {
+    if (message.trackId !== undefined && message.trackId !== "") {
       writer.uint32(18).string(message.trackId);
     }
     if (message.file !== undefined) {
@@ -1296,8 +1278,8 @@ export const TrackEgressRequest = {
 
   fromJSON(object: any): TrackEgressRequest {
     return {
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      trackId: isSet(object.trackId) ? String(object.trackId) : '',
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      trackId: isSet(object.trackId) ? String(object.trackId) : "",
       file: isSet(object.file) ? DirectFileOutput.fromJSON(object.file) : undefined,
       websocketUrl: isSet(object.websocketUrl) ? String(object.websocketUrl) : undefined,
     };
@@ -1307,20 +1289,18 @@ export const TrackEgressRequest = {
     const obj: any = {};
     message.roomName !== undefined && (obj.roomName = message.roomName);
     message.trackId !== undefined && (obj.trackId = message.trackId);
-    message.file !== undefined &&
-      (obj.file = message.file ? DirectFileOutput.toJSON(message.file) : undefined);
+    message.file !== undefined && (obj.file = message.file ? DirectFileOutput.toJSON(message.file) : undefined);
     message.websocketUrl !== undefined && (obj.websocketUrl = message.websocketUrl);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<TrackEgressRequest>, I>>(object: I): TrackEgressRequest {
     const message = createBaseTrackEgressRequest();
-    message.roomName = object.roomName ?? '';
-    message.trackId = object.trackId ?? '';
-    message.file =
-      object.file !== undefined && object.file !== null
-        ? DirectFileOutput.fromPartial(object.file)
-        : undefined;
+    message.roomName = object.roomName ?? "";
+    message.trackId = object.trackId ?? "";
+    message.file = (object.file !== undefined && object.file !== null)
+      ? DirectFileOutput.fromPartial(object.file)
+      : undefined;
     message.websocketUrl = object.websocketUrl ?? undefined;
     return message;
   },
@@ -1329,7 +1309,7 @@ export const TrackEgressRequest = {
 function createBaseEncodedFileOutput(): EncodedFileOutput {
   return {
     fileType: 0,
-    filepath: '',
+    filepath: "",
     disableManifest: false,
     s3: undefined,
     gcp: undefined,
@@ -1343,7 +1323,7 @@ export const EncodedFileOutput = {
     if (message.fileType !== undefined && message.fileType !== 0) {
       writer.uint32(8).int32(message.fileType);
     }
-    if (message.filepath !== undefined && message.filepath !== '') {
+    if (message.filepath !== undefined && message.filepath !== "") {
       writer.uint32(18).string(message.filepath);
     }
     if (message.disableManifest === true) {
@@ -1403,7 +1383,7 @@ export const EncodedFileOutput = {
   fromJSON(object: any): EncodedFileOutput {
     return {
       fileType: isSet(object.fileType) ? encodedFileTypeFromJSON(object.fileType) : 0,
-      filepath: isSet(object.filepath) ? String(object.filepath) : '',
+      filepath: isSet(object.filepath) ? String(object.filepath) : "",
       disableManifest: isSet(object.disableManifest) ? Boolean(object.disableManifest) : false,
       s3: isSet(object.s3) ? S3Upload.fromJSON(object.s3) : undefined,
       gcp: isSet(object.gcp) ? GCPUpload.fromJSON(object.gcp) : undefined,
@@ -1418,34 +1398,25 @@ export const EncodedFileOutput = {
     message.filepath !== undefined && (obj.filepath = message.filepath);
     message.disableManifest !== undefined && (obj.disableManifest = message.disableManifest);
     message.s3 !== undefined && (obj.s3 = message.s3 ? S3Upload.toJSON(message.s3) : undefined);
-    message.gcp !== undefined &&
-      (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
-    message.azure !== undefined &&
-      (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
-    message.aliOSS !== undefined &&
-      (obj.aliOSS = message.aliOSS ? AliOSSUpload.toJSON(message.aliOSS) : undefined);
+    message.gcp !== undefined && (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
+    message.azure !== undefined && (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
+    message.aliOSS !== undefined && (obj.aliOSS = message.aliOSS ? AliOSSUpload.toJSON(message.aliOSS) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<EncodedFileOutput>, I>>(object: I): EncodedFileOutput {
     const message = createBaseEncodedFileOutput();
     message.fileType = object.fileType ?? 0;
-    message.filepath = object.filepath ?? '';
+    message.filepath = object.filepath ?? "";
     message.disableManifest = object.disableManifest ?? false;
-    message.s3 =
-      object.s3 !== undefined && object.s3 !== null ? S3Upload.fromPartial(object.s3) : undefined;
-    message.gcp =
-      object.gcp !== undefined && object.gcp !== null
-        ? GCPUpload.fromPartial(object.gcp)
-        : undefined;
-    message.azure =
-      object.azure !== undefined && object.azure !== null
-        ? AzureBlobUpload.fromPartial(object.azure)
-        : undefined;
-    message.aliOSS =
-      object.aliOSS !== undefined && object.aliOSS !== null
-        ? AliOSSUpload.fromPartial(object.aliOSS)
-        : undefined;
+    message.s3 = (object.s3 !== undefined && object.s3 !== null) ? S3Upload.fromPartial(object.s3) : undefined;
+    message.gcp = (object.gcp !== undefined && object.gcp !== null) ? GCPUpload.fromPartial(object.gcp) : undefined;
+    message.azure = (object.azure !== undefined && object.azure !== null)
+      ? AzureBlobUpload.fromPartial(object.azure)
+      : undefined;
+    message.aliOSS = (object.aliOSS !== undefined && object.aliOSS !== null)
+      ? AliOSSUpload.fromPartial(object.aliOSS)
+      : undefined;
     return message;
   },
 };
@@ -1453,8 +1424,8 @@ export const EncodedFileOutput = {
 function createBaseSegmentedFileOutput(): SegmentedFileOutput {
   return {
     protocol: 0,
-    filenamePrefix: '',
-    playlistName: '',
+    filenamePrefix: "",
+    playlistName: "",
     segmentDuration: 0,
     filenameSuffix: 0,
     disableManifest: false,
@@ -1470,10 +1441,10 @@ export const SegmentedFileOutput = {
     if (message.protocol !== undefined && message.protocol !== 0) {
       writer.uint32(8).int32(message.protocol);
     }
-    if (message.filenamePrefix !== undefined && message.filenamePrefix !== '') {
+    if (message.filenamePrefix !== undefined && message.filenamePrefix !== "") {
       writer.uint32(18).string(message.filenamePrefix);
     }
-    if (message.playlistName !== undefined && message.playlistName !== '') {
+    if (message.playlistName !== undefined && message.playlistName !== "") {
       writer.uint32(26).string(message.playlistName);
     }
     if (message.segmentDuration !== undefined && message.segmentDuration !== 0) {
@@ -1548,12 +1519,10 @@ export const SegmentedFileOutput = {
   fromJSON(object: any): SegmentedFileOutput {
     return {
       protocol: isSet(object.protocol) ? segmentedFileProtocolFromJSON(object.protocol) : 0,
-      filenamePrefix: isSet(object.filenamePrefix) ? String(object.filenamePrefix) : '',
-      playlistName: isSet(object.playlistName) ? String(object.playlistName) : '',
+      filenamePrefix: isSet(object.filenamePrefix) ? String(object.filenamePrefix) : "",
+      playlistName: isSet(object.playlistName) ? String(object.playlistName) : "",
       segmentDuration: isSet(object.segmentDuration) ? Number(object.segmentDuration) : 0,
-      filenameSuffix: isSet(object.filenameSuffix)
-        ? segmentedFileSuffixFromJSON(object.filenameSuffix)
-        : 0,
+      filenameSuffix: isSet(object.filenameSuffix) ? segmentedFileSuffixFromJSON(object.filenameSuffix) : 0,
       disableManifest: isSet(object.disableManifest) ? Boolean(object.disableManifest) : false,
       s3: isSet(object.s3) ? S3Upload.fromJSON(object.s3) : undefined,
       gcp: isSet(object.gcp) ? GCPUpload.fromJSON(object.gcp) : undefined,
@@ -1564,67 +1533,46 @@ export const SegmentedFileOutput = {
 
   toJSON(message: SegmentedFileOutput): unknown {
     const obj: any = {};
-    message.protocol !== undefined &&
-      (obj.protocol = segmentedFileProtocolToJSON(message.protocol));
+    message.protocol !== undefined && (obj.protocol = segmentedFileProtocolToJSON(message.protocol));
     message.filenamePrefix !== undefined && (obj.filenamePrefix = message.filenamePrefix);
     message.playlistName !== undefined && (obj.playlistName = message.playlistName);
-    message.segmentDuration !== undefined &&
-      (obj.segmentDuration = Math.round(message.segmentDuration));
-    message.filenameSuffix !== undefined &&
-      (obj.filenameSuffix = segmentedFileSuffixToJSON(message.filenameSuffix));
+    message.segmentDuration !== undefined && (obj.segmentDuration = Math.round(message.segmentDuration));
+    message.filenameSuffix !== undefined && (obj.filenameSuffix = segmentedFileSuffixToJSON(message.filenameSuffix));
     message.disableManifest !== undefined && (obj.disableManifest = message.disableManifest);
     message.s3 !== undefined && (obj.s3 = message.s3 ? S3Upload.toJSON(message.s3) : undefined);
-    message.gcp !== undefined &&
-      (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
-    message.azure !== undefined &&
-      (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
-    message.aliOSS !== undefined &&
-      (obj.aliOSS = message.aliOSS ? AliOSSUpload.toJSON(message.aliOSS) : undefined);
+    message.gcp !== undefined && (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
+    message.azure !== undefined && (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
+    message.aliOSS !== undefined && (obj.aliOSS = message.aliOSS ? AliOSSUpload.toJSON(message.aliOSS) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SegmentedFileOutput>, I>>(
-    object: I,
-  ): SegmentedFileOutput {
+  fromPartial<I extends Exact<DeepPartial<SegmentedFileOutput>, I>>(object: I): SegmentedFileOutput {
     const message = createBaseSegmentedFileOutput();
     message.protocol = object.protocol ?? 0;
-    message.filenamePrefix = object.filenamePrefix ?? '';
-    message.playlistName = object.playlistName ?? '';
+    message.filenamePrefix = object.filenamePrefix ?? "";
+    message.playlistName = object.playlistName ?? "";
     message.segmentDuration = object.segmentDuration ?? 0;
     message.filenameSuffix = object.filenameSuffix ?? 0;
     message.disableManifest = object.disableManifest ?? false;
-    message.s3 =
-      object.s3 !== undefined && object.s3 !== null ? S3Upload.fromPartial(object.s3) : undefined;
-    message.gcp =
-      object.gcp !== undefined && object.gcp !== null
-        ? GCPUpload.fromPartial(object.gcp)
-        : undefined;
-    message.azure =
-      object.azure !== undefined && object.azure !== null
-        ? AzureBlobUpload.fromPartial(object.azure)
-        : undefined;
-    message.aliOSS =
-      object.aliOSS !== undefined && object.aliOSS !== null
-        ? AliOSSUpload.fromPartial(object.aliOSS)
-        : undefined;
+    message.s3 = (object.s3 !== undefined && object.s3 !== null) ? S3Upload.fromPartial(object.s3) : undefined;
+    message.gcp = (object.gcp !== undefined && object.gcp !== null) ? GCPUpload.fromPartial(object.gcp) : undefined;
+    message.azure = (object.azure !== undefined && object.azure !== null)
+      ? AzureBlobUpload.fromPartial(object.azure)
+      : undefined;
+    message.aliOSS = (object.aliOSS !== undefined && object.aliOSS !== null)
+      ? AliOSSUpload.fromPartial(object.aliOSS)
+      : undefined;
     return message;
   },
 };
 
 function createBaseDirectFileOutput(): DirectFileOutput {
-  return {
-    filepath: '',
-    disableManifest: false,
-    s3: undefined,
-    gcp: undefined,
-    azure: undefined,
-    aliOSS: undefined,
-  };
+  return { filepath: "", disableManifest: false, s3: undefined, gcp: undefined, azure: undefined, aliOSS: undefined };
 }
 
 export const DirectFileOutput = {
   encode(message: DirectFileOutput, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.filepath !== undefined && message.filepath !== '') {
+    if (message.filepath !== undefined && message.filepath !== "") {
       writer.uint32(10).string(message.filepath);
     }
     if (message.disableManifest === true) {
@@ -1680,7 +1628,7 @@ export const DirectFileOutput = {
 
   fromJSON(object: any): DirectFileOutput {
     return {
-      filepath: isSet(object.filepath) ? String(object.filepath) : '',
+      filepath: isSet(object.filepath) ? String(object.filepath) : "",
       disableManifest: isSet(object.disableManifest) ? Boolean(object.disableManifest) : false,
       s3: isSet(object.s3) ? S3Upload.fromJSON(object.s3) : undefined,
       gcp: isSet(object.gcp) ? GCPUpload.fromJSON(object.gcp) : undefined,
@@ -1694,65 +1642,56 @@ export const DirectFileOutput = {
     message.filepath !== undefined && (obj.filepath = message.filepath);
     message.disableManifest !== undefined && (obj.disableManifest = message.disableManifest);
     message.s3 !== undefined && (obj.s3 = message.s3 ? S3Upload.toJSON(message.s3) : undefined);
-    message.gcp !== undefined &&
-      (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
-    message.azure !== undefined &&
-      (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
-    message.aliOSS !== undefined &&
-      (obj.aliOSS = message.aliOSS ? AliOSSUpload.toJSON(message.aliOSS) : undefined);
+    message.gcp !== undefined && (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
+    message.azure !== undefined && (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
+    message.aliOSS !== undefined && (obj.aliOSS = message.aliOSS ? AliOSSUpload.toJSON(message.aliOSS) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<DirectFileOutput>, I>>(object: I): DirectFileOutput {
     const message = createBaseDirectFileOutput();
-    message.filepath = object.filepath ?? '';
+    message.filepath = object.filepath ?? "";
     message.disableManifest = object.disableManifest ?? false;
-    message.s3 =
-      object.s3 !== undefined && object.s3 !== null ? S3Upload.fromPartial(object.s3) : undefined;
-    message.gcp =
-      object.gcp !== undefined && object.gcp !== null
-        ? GCPUpload.fromPartial(object.gcp)
-        : undefined;
-    message.azure =
-      object.azure !== undefined && object.azure !== null
-        ? AzureBlobUpload.fromPartial(object.azure)
-        : undefined;
-    message.aliOSS =
-      object.aliOSS !== undefined && object.aliOSS !== null
-        ? AliOSSUpload.fromPartial(object.aliOSS)
-        : undefined;
+    message.s3 = (object.s3 !== undefined && object.s3 !== null) ? S3Upload.fromPartial(object.s3) : undefined;
+    message.gcp = (object.gcp !== undefined && object.gcp !== null) ? GCPUpload.fromPartial(object.gcp) : undefined;
+    message.azure = (object.azure !== undefined && object.azure !== null)
+      ? AzureBlobUpload.fromPartial(object.azure)
+      : undefined;
+    message.aliOSS = (object.aliOSS !== undefined && object.aliOSS !== null)
+      ? AliOSSUpload.fromPartial(object.aliOSS)
+      : undefined;
     return message;
   },
 };
 
 function createBaseS3Upload(): S3Upload {
   return {
-    accessKey: '',
-    secret: '',
-    region: '',
-    endpoint: '',
-    bucket: '',
+    accessKey: "",
+    secret: "",
+    region: "",
+    endpoint: "",
+    bucket: "",
     forcePathStyle: false,
     metadata: {},
-    tagging: '',
+    tagging: "",
   };
 }
 
 export const S3Upload = {
   encode(message: S3Upload, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.accessKey !== undefined && message.accessKey !== '') {
+    if (message.accessKey !== undefined && message.accessKey !== "") {
       writer.uint32(10).string(message.accessKey);
     }
-    if (message.secret !== undefined && message.secret !== '') {
+    if (message.secret !== undefined && message.secret !== "") {
       writer.uint32(18).string(message.secret);
     }
-    if (message.region !== undefined && message.region !== '') {
+    if (message.region !== undefined && message.region !== "") {
       writer.uint32(26).string(message.region);
     }
-    if (message.endpoint !== undefined && message.endpoint !== '') {
+    if (message.endpoint !== undefined && message.endpoint !== "") {
       writer.uint32(34).string(message.endpoint);
     }
-    if (message.bucket !== undefined && message.bucket !== '') {
+    if (message.bucket !== undefined && message.bucket !== "") {
       writer.uint32(42).string(message.bucket);
     }
     if (message.forcePathStyle === true) {
@@ -1761,7 +1700,7 @@ export const S3Upload = {
     Object.entries(message.metadata || {}).forEach(([key, value]) => {
       S3Upload_MetadataEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).ldelim();
     });
-    if (message.tagging !== undefined && message.tagging !== '') {
+    if (message.tagging !== undefined && message.tagging !== "") {
       writer.uint32(66).string(message.tagging);
     }
     return writer;
@@ -1811,19 +1750,19 @@ export const S3Upload = {
 
   fromJSON(object: any): S3Upload {
     return {
-      accessKey: isSet(object.accessKey) ? String(object.accessKey) : '',
-      secret: isSet(object.secret) ? String(object.secret) : '',
-      region: isSet(object.region) ? String(object.region) : '',
-      endpoint: isSet(object.endpoint) ? String(object.endpoint) : '',
-      bucket: isSet(object.bucket) ? String(object.bucket) : '',
+      accessKey: isSet(object.accessKey) ? String(object.accessKey) : "",
+      secret: isSet(object.secret) ? String(object.secret) : "",
+      region: isSet(object.region) ? String(object.region) : "",
+      endpoint: isSet(object.endpoint) ? String(object.endpoint) : "",
+      bucket: isSet(object.bucket) ? String(object.bucket) : "",
       forcePathStyle: isSet(object.forcePathStyle) ? Boolean(object.forcePathStyle) : false,
       metadata: isObject(object.metadata)
         ? Object.entries(object.metadata).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-            acc[key] = String(value);
-            return acc;
-          }, {})
+          acc[key] = String(value);
+          return acc;
+        }, {})
         : {},
-      tagging: isSet(object.tagging) ? String(object.tagging) : '',
+      tagging: isSet(object.tagging) ? String(object.tagging) : "",
     };
   },
 
@@ -1847,36 +1786,33 @@ export const S3Upload = {
 
   fromPartial<I extends Exact<DeepPartial<S3Upload>, I>>(object: I): S3Upload {
     const message = createBaseS3Upload();
-    message.accessKey = object.accessKey ?? '';
-    message.secret = object.secret ?? '';
-    message.region = object.region ?? '';
-    message.endpoint = object.endpoint ?? '';
-    message.bucket = object.bucket ?? '';
+    message.accessKey = object.accessKey ?? "";
+    message.secret = object.secret ?? "";
+    message.region = object.region ?? "";
+    message.endpoint = object.endpoint ?? "";
+    message.bucket = object.bucket ?? "";
     message.forcePathStyle = object.forcePathStyle ?? false;
-    message.metadata = Object.entries(object.metadata ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        if (value !== undefined) {
-          acc[key] = String(value);
-        }
-        return acc;
-      },
-      {},
-    );
-    message.tagging = object.tagging ?? '';
+    message.metadata = Object.entries(object.metadata ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+      if (value !== undefined) {
+        acc[key] = String(value);
+      }
+      return acc;
+    }, {});
+    message.tagging = object.tagging ?? "";
     return message;
   },
 };
 
 function createBaseS3Upload_MetadataEntry(): S3Upload_MetadataEntry {
-  return { key: '', value: '' };
+  return { key: "", value: "" };
 }
 
 export const S3Upload_MetadataEntry = {
   encode(message: S3Upload_MetadataEntry, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.key !== '') {
+    if (message.key !== "") {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== '') {
+    if (message.value !== "") {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -1904,10 +1840,7 @@ export const S3Upload_MetadataEntry = {
   },
 
   fromJSON(object: any): S3Upload_MetadataEntry {
-    return {
-      key: isSet(object.key) ? String(object.key) : '',
-      value: isSet(object.value) ? String(object.value) : '',
-    };
+    return { key: isSet(object.key) ? String(object.key) : "", value: isSet(object.value) ? String(object.value) : "" };
   },
 
   toJSON(message: S3Upload_MetadataEntry): unknown {
@@ -1917,26 +1850,24 @@ export const S3Upload_MetadataEntry = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<S3Upload_MetadataEntry>, I>>(
-    object: I,
-  ): S3Upload_MetadataEntry {
+  fromPartial<I extends Exact<DeepPartial<S3Upload_MetadataEntry>, I>>(object: I): S3Upload_MetadataEntry {
     const message = createBaseS3Upload_MetadataEntry();
-    message.key = object.key ?? '';
-    message.value = object.value ?? '';
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
     return message;
   },
 };
 
 function createBaseGCPUpload(): GCPUpload {
-  return { credentials: '', bucket: '' };
+  return { credentials: "", bucket: "" };
 }
 
 export const GCPUpload = {
   encode(message: GCPUpload, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.credentials !== undefined && message.credentials !== '') {
+    if (message.credentials !== undefined && message.credentials !== "") {
       writer.uint32(10).string(message.credentials);
     }
-    if (message.bucket !== undefined && message.bucket !== '') {
+    if (message.bucket !== undefined && message.bucket !== "") {
       writer.uint32(18).string(message.bucket);
     }
     return writer;
@@ -1965,8 +1896,8 @@ export const GCPUpload = {
 
   fromJSON(object: any): GCPUpload {
     return {
-      credentials: isSet(object.credentials) ? String(object.credentials) : '',
-      bucket: isSet(object.bucket) ? String(object.bucket) : '',
+      credentials: isSet(object.credentials) ? String(object.credentials) : "",
+      bucket: isSet(object.bucket) ? String(object.bucket) : "",
     };
   },
 
@@ -1979,25 +1910,25 @@ export const GCPUpload = {
 
   fromPartial<I extends Exact<DeepPartial<GCPUpload>, I>>(object: I): GCPUpload {
     const message = createBaseGCPUpload();
-    message.credentials = object.credentials ?? '';
-    message.bucket = object.bucket ?? '';
+    message.credentials = object.credentials ?? "";
+    message.bucket = object.bucket ?? "";
     return message;
   },
 };
 
 function createBaseAzureBlobUpload(): AzureBlobUpload {
-  return { accountName: '', accountKey: '', containerName: '' };
+  return { accountName: "", accountKey: "", containerName: "" };
 }
 
 export const AzureBlobUpload = {
   encode(message: AzureBlobUpload, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.accountName !== undefined && message.accountName !== '') {
+    if (message.accountName !== undefined && message.accountName !== "") {
       writer.uint32(10).string(message.accountName);
     }
-    if (message.accountKey !== undefined && message.accountKey !== '') {
+    if (message.accountKey !== undefined && message.accountKey !== "") {
       writer.uint32(18).string(message.accountKey);
     }
-    if (message.containerName !== undefined && message.containerName !== '') {
+    if (message.containerName !== undefined && message.containerName !== "") {
       writer.uint32(26).string(message.containerName);
     }
     return writer;
@@ -2029,9 +1960,9 @@ export const AzureBlobUpload = {
 
   fromJSON(object: any): AzureBlobUpload {
     return {
-      accountName: isSet(object.accountName) ? String(object.accountName) : '',
-      accountKey: isSet(object.accountKey) ? String(object.accountKey) : '',
-      containerName: isSet(object.containerName) ? String(object.containerName) : '',
+      accountName: isSet(object.accountName) ? String(object.accountName) : "",
+      accountKey: isSet(object.accountKey) ? String(object.accountKey) : "",
+      containerName: isSet(object.containerName) ? String(object.containerName) : "",
     };
   },
 
@@ -2045,32 +1976,32 @@ export const AzureBlobUpload = {
 
   fromPartial<I extends Exact<DeepPartial<AzureBlobUpload>, I>>(object: I): AzureBlobUpload {
     const message = createBaseAzureBlobUpload();
-    message.accountName = object.accountName ?? '';
-    message.accountKey = object.accountKey ?? '';
-    message.containerName = object.containerName ?? '';
+    message.accountName = object.accountName ?? "";
+    message.accountKey = object.accountKey ?? "";
+    message.containerName = object.containerName ?? "";
     return message;
   },
 };
 
 function createBaseAliOSSUpload(): AliOSSUpload {
-  return { accessKey: '', secret: '', region: '', endpoint: '', bucket: '' };
+  return { accessKey: "", secret: "", region: "", endpoint: "", bucket: "" };
 }
 
 export const AliOSSUpload = {
   encode(message: AliOSSUpload, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.accessKey !== undefined && message.accessKey !== '') {
+    if (message.accessKey !== undefined && message.accessKey !== "") {
       writer.uint32(10).string(message.accessKey);
     }
-    if (message.secret !== undefined && message.secret !== '') {
+    if (message.secret !== undefined && message.secret !== "") {
       writer.uint32(18).string(message.secret);
     }
-    if (message.region !== undefined && message.region !== '') {
+    if (message.region !== undefined && message.region !== "") {
       writer.uint32(26).string(message.region);
     }
-    if (message.endpoint !== undefined && message.endpoint !== '') {
+    if (message.endpoint !== undefined && message.endpoint !== "") {
       writer.uint32(34).string(message.endpoint);
     }
-    if (message.bucket !== undefined && message.bucket !== '') {
+    if (message.bucket !== undefined && message.bucket !== "") {
       writer.uint32(42).string(message.bucket);
     }
     return writer;
@@ -2108,11 +2039,11 @@ export const AliOSSUpload = {
 
   fromJSON(object: any): AliOSSUpload {
     return {
-      accessKey: isSet(object.accessKey) ? String(object.accessKey) : '',
-      secret: isSet(object.secret) ? String(object.secret) : '',
-      region: isSet(object.region) ? String(object.region) : '',
-      endpoint: isSet(object.endpoint) ? String(object.endpoint) : '',
-      bucket: isSet(object.bucket) ? String(object.bucket) : '',
+      accessKey: isSet(object.accessKey) ? String(object.accessKey) : "",
+      secret: isSet(object.secret) ? String(object.secret) : "",
+      region: isSet(object.region) ? String(object.region) : "",
+      endpoint: isSet(object.endpoint) ? String(object.endpoint) : "",
+      bucket: isSet(object.bucket) ? String(object.bucket) : "",
     };
   },
 
@@ -2128,11 +2059,11 @@ export const AliOSSUpload = {
 
   fromPartial<I extends Exact<DeepPartial<AliOSSUpload>, I>>(object: I): AliOSSUpload {
     const message = createBaseAliOSSUpload();
-    message.accessKey = object.accessKey ?? '';
-    message.secret = object.secret ?? '';
-    message.region = object.region ?? '';
-    message.endpoint = object.endpoint ?? '';
-    message.bucket = object.bucket ?? '';
+    message.accessKey = object.accessKey ?? "";
+    message.secret = object.secret ?? "";
+    message.region = object.region ?? "";
+    message.endpoint = object.endpoint ?? "";
+    message.bucket = object.bucket ?? "";
     return message;
   },
 };
@@ -2319,8 +2250,7 @@ export const EncodingOptions = {
     message.framerate !== undefined && (obj.framerate = Math.round(message.framerate));
     message.audioCodec !== undefined && (obj.audioCodec = audioCodecToJSON(message.audioCodec));
     message.audioBitrate !== undefined && (obj.audioBitrate = Math.round(message.audioBitrate));
-    message.audioFrequency !== undefined &&
-      (obj.audioFrequency = Math.round(message.audioFrequency));
+    message.audioFrequency !== undefined && (obj.audioFrequency = Math.round(message.audioFrequency));
     message.videoCodec !== undefined && (obj.videoCodec = videoCodecToJSON(message.videoCodec));
     message.videoBitrate !== undefined && (obj.videoBitrate = Math.round(message.videoBitrate));
     message.keyFrameInterval !== undefined && (obj.keyFrameInterval = message.keyFrameInterval);
@@ -2344,15 +2274,15 @@ export const EncodingOptions = {
 };
 
 function createBaseUpdateLayoutRequest(): UpdateLayoutRequest {
-  return { egressId: '', layout: '' };
+  return { egressId: "", layout: "" };
 }
 
 export const UpdateLayoutRequest = {
   encode(message: UpdateLayoutRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.egressId !== undefined && message.egressId !== '') {
+    if (message.egressId !== undefined && message.egressId !== "") {
       writer.uint32(10).string(message.egressId);
     }
-    if (message.layout !== undefined && message.layout !== '') {
+    if (message.layout !== undefined && message.layout !== "") {
       writer.uint32(18).string(message.layout);
     }
     return writer;
@@ -2381,8 +2311,8 @@ export const UpdateLayoutRequest = {
 
   fromJSON(object: any): UpdateLayoutRequest {
     return {
-      egressId: isSet(object.egressId) ? String(object.egressId) : '',
-      layout: isSet(object.layout) ? String(object.layout) : '',
+      egressId: isSet(object.egressId) ? String(object.egressId) : "",
+      layout: isSet(object.layout) ? String(object.layout) : "",
     };
   },
 
@@ -2393,23 +2323,21 @@ export const UpdateLayoutRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateLayoutRequest>, I>>(
-    object: I,
-  ): UpdateLayoutRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdateLayoutRequest>, I>>(object: I): UpdateLayoutRequest {
     const message = createBaseUpdateLayoutRequest();
-    message.egressId = object.egressId ?? '';
-    message.layout = object.layout ?? '';
+    message.egressId = object.egressId ?? "";
+    message.layout = object.layout ?? "";
     return message;
   },
 };
 
 function createBaseUpdateStreamRequest(): UpdateStreamRequest {
-  return { egressId: '', addOutputUrls: [], removeOutputUrls: [] };
+  return { egressId: "", addOutputUrls: [], removeOutputUrls: [] };
 }
 
 export const UpdateStreamRequest = {
   encode(message: UpdateStreamRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.egressId !== undefined && message.egressId !== '') {
+    if (message.egressId !== undefined && message.egressId !== "") {
       writer.uint32(10).string(message.egressId);
     }
     if (message.addOutputUrls !== undefined && message.addOutputUrls.length !== 0) {
@@ -2451,10 +2379,8 @@ export const UpdateStreamRequest = {
 
   fromJSON(object: any): UpdateStreamRequest {
     return {
-      egressId: isSet(object.egressId) ? String(object.egressId) : '',
-      addOutputUrls: Array.isArray(object?.addOutputUrls)
-        ? object.addOutputUrls.map((e: any) => String(e))
-        : [],
+      egressId: isSet(object.egressId) ? String(object.egressId) : "",
+      addOutputUrls: Array.isArray(object?.addOutputUrls) ? object.addOutputUrls.map((e: any) => String(e)) : [],
       removeOutputUrls: Array.isArray(object?.removeOutputUrls)
         ? object.removeOutputUrls.map((e: any) => String(e))
         : [],
@@ -2477,11 +2403,9 @@ export const UpdateStreamRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateStreamRequest>, I>>(
-    object: I,
-  ): UpdateStreamRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdateStreamRequest>, I>>(object: I): UpdateStreamRequest {
     const message = createBaseUpdateStreamRequest();
-    message.egressId = object.egressId ?? '';
+    message.egressId = object.egressId ?? "";
     message.addOutputUrls = object.addOutputUrls?.map((e) => e) || [];
     message.removeOutputUrls = object.removeOutputUrls?.map((e) => e) || [];
     return message;
@@ -2489,15 +2413,15 @@ export const UpdateStreamRequest = {
 };
 
 function createBaseListEgressRequest(): ListEgressRequest {
-  return { roomName: '', egressId: '', active: false };
+  return { roomName: "", egressId: "", active: false };
 }
 
 export const ListEgressRequest = {
   encode(message: ListEgressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(10).string(message.roomName);
     }
-    if (message.egressId !== undefined && message.egressId !== '') {
+    if (message.egressId !== undefined && message.egressId !== "") {
       writer.uint32(18).string(message.egressId);
     }
     if (message.active === true) {
@@ -2532,8 +2456,8 @@ export const ListEgressRequest = {
 
   fromJSON(object: any): ListEgressRequest {
     return {
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      egressId: isSet(object.egressId) ? String(object.egressId) : '',
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      egressId: isSet(object.egressId) ? String(object.egressId) : "",
       active: isSet(object.active) ? Boolean(object.active) : false,
     };
   },
@@ -2548,8 +2472,8 @@ export const ListEgressRequest = {
 
   fromPartial<I extends Exact<DeepPartial<ListEgressRequest>, I>>(object: I): ListEgressRequest {
     const message = createBaseListEgressRequest();
-    message.roomName = object.roomName ?? '';
-    message.egressId = object.egressId ?? '';
+    message.roomName = object.roomName ?? "";
+    message.egressId = object.egressId ?? "";
     message.active = object.active ?? false;
     return message;
   },
@@ -2588,17 +2512,13 @@ export const ListEgressResponse = {
   },
 
   fromJSON(object: any): ListEgressResponse {
-    return {
-      items: Array.isArray(object?.items)
-        ? object.items.map((e: any) => EgressInfo.fromJSON(e))
-        : [],
-    };
+    return { items: Array.isArray(object?.items) ? object.items.map((e: any) => EgressInfo.fromJSON(e)) : [] };
   },
 
   toJSON(message: ListEgressResponse): unknown {
     const obj: any = {};
     if (message.items) {
-      obj.items = message.items.map((e) => (e ? EgressInfo.toJSON(e) : undefined));
+      obj.items = message.items.map((e) => e ? EgressInfo.toJSON(e) : undefined);
     } else {
       obj.items = [];
     }
@@ -2613,12 +2533,12 @@ export const ListEgressResponse = {
 };
 
 function createBaseStopEgressRequest(): StopEgressRequest {
-  return { egressId: '' };
+  return { egressId: "" };
 }
 
 export const StopEgressRequest = {
   encode(message: StopEgressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.egressId !== undefined && message.egressId !== '') {
+    if (message.egressId !== undefined && message.egressId !== "") {
       writer.uint32(10).string(message.egressId);
     }
     return writer;
@@ -2643,9 +2563,7 @@ export const StopEgressRequest = {
   },
 
   fromJSON(object: any): StopEgressRequest {
-    return {
-      egressId: isSet(object.egressId) ? String(object.egressId) : '',
-    };
+    return { egressId: isSet(object.egressId) ? String(object.egressId) : "" };
   },
 
   toJSON(message: StopEgressRequest): unknown {
@@ -2656,20 +2574,21 @@ export const StopEgressRequest = {
 
   fromPartial<I extends Exact<DeepPartial<StopEgressRequest>, I>>(object: I): StopEgressRequest {
     const message = createBaseStopEgressRequest();
-    message.egressId = object.egressId ?? '';
+    message.egressId = object.egressId ?? "";
     return message;
   },
 };
 
 function createBaseEgressInfo(): EgressInfo {
   return {
-    egressId: '',
-    roomId: '',
-    roomName: '',
+    egressId: "",
+    roomId: "",
+    roomName: "",
     status: 0,
     startedAt: 0,
     endedAt: 0,
-    error: '',
+    updatedAt: 0,
+    error: "",
     roomComposite: undefined,
     trackComposite: undefined,
     track: undefined,
@@ -2685,13 +2604,13 @@ function createBaseEgressInfo(): EgressInfo {
 
 export const EgressInfo = {
   encode(message: EgressInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.egressId !== undefined && message.egressId !== '') {
+    if (message.egressId !== undefined && message.egressId !== "") {
       writer.uint32(10).string(message.egressId);
     }
-    if (message.roomId !== undefined && message.roomId !== '') {
+    if (message.roomId !== undefined && message.roomId !== "") {
       writer.uint32(18).string(message.roomId);
     }
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(106).string(message.roomName);
     }
     if (message.status !== undefined && message.status !== 0) {
@@ -2703,7 +2622,10 @@ export const EgressInfo = {
     if (message.endedAt !== undefined && message.endedAt !== 0) {
       writer.uint32(88).int64(message.endedAt);
     }
-    if (message.error !== undefined && message.error !== '') {
+    if (message.updatedAt !== undefined && message.updatedAt !== 0) {
+      writer.uint32(144).int64(message.updatedAt);
+    }
+    if (message.error !== undefined && message.error !== "") {
       writer.uint32(74).string(message.error);
     }
     if (message.roomComposite !== undefined) {
@@ -2770,6 +2692,9 @@ export const EgressInfo = {
         case 11:
           message.endedAt = longToNumber(reader.int64() as Long);
           break;
+        case 18:
+          message.updatedAt = longToNumber(reader.int64() as Long);
+          break;
         case 9:
           message.error = reader.string();
           break;
@@ -2813,13 +2738,14 @@ export const EgressInfo = {
 
   fromJSON(object: any): EgressInfo {
     return {
-      egressId: isSet(object.egressId) ? String(object.egressId) : '',
-      roomId: isSet(object.roomId) ? String(object.roomId) : '',
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
+      egressId: isSet(object.egressId) ? String(object.egressId) : "",
+      roomId: isSet(object.roomId) ? String(object.roomId) : "",
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
       status: isSet(object.status) ? egressStatusFromJSON(object.status) : 0,
       startedAt: isSet(object.startedAt) ? Number(object.startedAt) : 0,
       endedAt: isSet(object.endedAt) ? Number(object.endedAt) : 0,
-      error: isSet(object.error) ? String(object.error) : '',
+      updatedAt: isSet(object.updatedAt) ? Number(object.updatedAt) : 0,
+      error: isSet(object.error) ? String(object.error) : "",
       roomComposite: isSet(object.roomComposite)
         ? RoomCompositeEgressRequest.fromJSON(object.roomComposite)
         : undefined,
@@ -2834,9 +2760,7 @@ export const EgressInfo = {
       streamResults: Array.isArray(object?.streamResults)
         ? object.streamResults.map((e: any) => StreamInfo.fromJSON(e))
         : [],
-      fileResults: Array.isArray(object?.fileResults)
-        ? object.fileResults.map((e: any) => FileInfo.fromJSON(e))
-        : [],
+      fileResults: Array.isArray(object?.fileResults) ? object.fileResults.map((e: any) => FileInfo.fromJSON(e)) : [],
       segmentResults: Array.isArray(object?.segmentResults)
         ? object.segmentResults.map((e: any) => SegmentsInfo.fromJSON(e))
         : [],
@@ -2851,39 +2775,33 @@ export const EgressInfo = {
     message.status !== undefined && (obj.status = egressStatusToJSON(message.status));
     message.startedAt !== undefined && (obj.startedAt = Math.round(message.startedAt));
     message.endedAt !== undefined && (obj.endedAt = Math.round(message.endedAt));
+    message.updatedAt !== undefined && (obj.updatedAt = Math.round(message.updatedAt));
     message.error !== undefined && (obj.error = message.error);
     message.roomComposite !== undefined &&
       (obj.roomComposite = message.roomComposite
         ? RoomCompositeEgressRequest.toJSON(message.roomComposite)
         : undefined);
-    message.trackComposite !== undefined &&
-      (obj.trackComposite = message.trackComposite
-        ? TrackCompositeEgressRequest.toJSON(message.trackComposite)
-        : undefined);
-    message.track !== undefined &&
-      (obj.track = message.track ? TrackEgressRequest.toJSON(message.track) : undefined);
-    message.web !== undefined &&
-      (obj.web = message.web ? WebEgressRequest.toJSON(message.web) : undefined);
-    message.stream !== undefined &&
-      (obj.stream = message.stream ? StreamInfoList.toJSON(message.stream) : undefined);
-    message.file !== undefined &&
-      (obj.file = message.file ? FileInfo.toJSON(message.file) : undefined);
+    message.trackComposite !== undefined && (obj.trackComposite = message.trackComposite
+      ? TrackCompositeEgressRequest.toJSON(message.trackComposite)
+      : undefined);
+    message.track !== undefined && (obj.track = message.track ? TrackEgressRequest.toJSON(message.track) : undefined);
+    message.web !== undefined && (obj.web = message.web ? WebEgressRequest.toJSON(message.web) : undefined);
+    message.stream !== undefined && (obj.stream = message.stream ? StreamInfoList.toJSON(message.stream) : undefined);
+    message.file !== undefined && (obj.file = message.file ? FileInfo.toJSON(message.file) : undefined);
     message.segments !== undefined &&
       (obj.segments = message.segments ? SegmentsInfo.toJSON(message.segments) : undefined);
     if (message.streamResults) {
-      obj.streamResults = message.streamResults.map((e) => (e ? StreamInfo.toJSON(e) : undefined));
+      obj.streamResults = message.streamResults.map((e) => e ? StreamInfo.toJSON(e) : undefined);
     } else {
       obj.streamResults = [];
     }
     if (message.fileResults) {
-      obj.fileResults = message.fileResults.map((e) => (e ? FileInfo.toJSON(e) : undefined));
+      obj.fileResults = message.fileResults.map((e) => e ? FileInfo.toJSON(e) : undefined);
     } else {
       obj.fileResults = [];
     }
     if (message.segmentResults) {
-      obj.segmentResults = message.segmentResults.map((e) =>
-        e ? SegmentsInfo.toJSON(e) : undefined,
-      );
+      obj.segmentResults = message.segmentResults.map((e) => e ? SegmentsInfo.toJSON(e) : undefined);
     } else {
       obj.segmentResults = [];
     }
@@ -2892,41 +2810,33 @@ export const EgressInfo = {
 
   fromPartial<I extends Exact<DeepPartial<EgressInfo>, I>>(object: I): EgressInfo {
     const message = createBaseEgressInfo();
-    message.egressId = object.egressId ?? '';
-    message.roomId = object.roomId ?? '';
-    message.roomName = object.roomName ?? '';
+    message.egressId = object.egressId ?? "";
+    message.roomId = object.roomId ?? "";
+    message.roomName = object.roomName ?? "";
     message.status = object.status ?? 0;
     message.startedAt = object.startedAt ?? 0;
     message.endedAt = object.endedAt ?? 0;
-    message.error = object.error ?? '';
-    message.roomComposite =
-      object.roomComposite !== undefined && object.roomComposite !== null
-        ? RoomCompositeEgressRequest.fromPartial(object.roomComposite)
-        : undefined;
-    message.trackComposite =
-      object.trackComposite !== undefined && object.trackComposite !== null
-        ? TrackCompositeEgressRequest.fromPartial(object.trackComposite)
-        : undefined;
-    message.track =
-      object.track !== undefined && object.track !== null
-        ? TrackEgressRequest.fromPartial(object.track)
-        : undefined;
-    message.web =
-      object.web !== undefined && object.web !== null
-        ? WebEgressRequest.fromPartial(object.web)
-        : undefined;
-    message.stream =
-      object.stream !== undefined && object.stream !== null
-        ? StreamInfoList.fromPartial(object.stream)
-        : undefined;
-    message.file =
-      object.file !== undefined && object.file !== null
-        ? FileInfo.fromPartial(object.file)
-        : undefined;
-    message.segments =
-      object.segments !== undefined && object.segments !== null
-        ? SegmentsInfo.fromPartial(object.segments)
-        : undefined;
+    message.updatedAt = object.updatedAt ?? 0;
+    message.error = object.error ?? "";
+    message.roomComposite = (object.roomComposite !== undefined && object.roomComposite !== null)
+      ? RoomCompositeEgressRequest.fromPartial(object.roomComposite)
+      : undefined;
+    message.trackComposite = (object.trackComposite !== undefined && object.trackComposite !== null)
+      ? TrackCompositeEgressRequest.fromPartial(object.trackComposite)
+      : undefined;
+    message.track = (object.track !== undefined && object.track !== null)
+      ? TrackEgressRequest.fromPartial(object.track)
+      : undefined;
+    message.web = (object.web !== undefined && object.web !== null)
+      ? WebEgressRequest.fromPartial(object.web)
+      : undefined;
+    message.stream = (object.stream !== undefined && object.stream !== null)
+      ? StreamInfoList.fromPartial(object.stream)
+      : undefined;
+    message.file = (object.file !== undefined && object.file !== null) ? FileInfo.fromPartial(object.file) : undefined;
+    message.segments = (object.segments !== undefined && object.segments !== null)
+      ? SegmentsInfo.fromPartial(object.segments)
+      : undefined;
     message.streamResults = object.streamResults?.map((e) => StreamInfo.fromPartial(e)) || [];
     message.fileResults = object.fileResults?.map((e) => FileInfo.fromPartial(e)) || [];
     message.segmentResults = object.segmentResults?.map((e) => SegmentsInfo.fromPartial(e)) || [];
@@ -2967,15 +2877,13 @@ export const StreamInfoList = {
   },
 
   fromJSON(object: any): StreamInfoList {
-    return {
-      info: Array.isArray(object?.info) ? object.info.map((e: any) => StreamInfo.fromJSON(e)) : [],
-    };
+    return { info: Array.isArray(object?.info) ? object.info.map((e: any) => StreamInfo.fromJSON(e)) : [] };
   },
 
   toJSON(message: StreamInfoList): unknown {
     const obj: any = {};
     if (message.info) {
-      obj.info = message.info.map((e) => (e ? StreamInfo.toJSON(e) : undefined));
+      obj.info = message.info.map((e) => e ? StreamInfo.toJSON(e) : undefined);
     } else {
       obj.info = [];
     }
@@ -2990,12 +2898,12 @@ export const StreamInfoList = {
 };
 
 function createBaseStreamInfo(): StreamInfo {
-  return { url: '', startedAt: 0, endedAt: 0, duration: 0, status: 0, error: '' };
+  return { url: "", startedAt: 0, endedAt: 0, duration: 0, status: 0, error: "" };
 }
 
 export const StreamInfo = {
   encode(message: StreamInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.url !== undefined && message.url !== '') {
+    if (message.url !== undefined && message.url !== "") {
       writer.uint32(10).string(message.url);
     }
     if (message.startedAt !== undefined && message.startedAt !== 0) {
@@ -3010,7 +2918,7 @@ export const StreamInfo = {
     if (message.status !== undefined && message.status !== 0) {
       writer.uint32(40).int32(message.status);
     }
-    if (message.error !== undefined && message.error !== '') {
+    if (message.error !== undefined && message.error !== "") {
       writer.uint32(50).string(message.error);
     }
     return writer;
@@ -3051,12 +2959,12 @@ export const StreamInfo = {
 
   fromJSON(object: any): StreamInfo {
     return {
-      url: isSet(object.url) ? String(object.url) : '',
+      url: isSet(object.url) ? String(object.url) : "",
       startedAt: isSet(object.startedAt) ? Number(object.startedAt) : 0,
       endedAt: isSet(object.endedAt) ? Number(object.endedAt) : 0,
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       status: isSet(object.status) ? streamInfo_StatusFromJSON(object.status) : 0,
-      error: isSet(object.error) ? String(object.error) : '',
+      error: isSet(object.error) ? String(object.error) : "",
     };
   },
 
@@ -3073,23 +2981,23 @@ export const StreamInfo = {
 
   fromPartial<I extends Exact<DeepPartial<StreamInfo>, I>>(object: I): StreamInfo {
     const message = createBaseStreamInfo();
-    message.url = object.url ?? '';
+    message.url = object.url ?? "";
     message.startedAt = object.startedAt ?? 0;
     message.endedAt = object.endedAt ?? 0;
     message.duration = object.duration ?? 0;
     message.status = object.status ?? 0;
-    message.error = object.error ?? '';
+    message.error = object.error ?? "";
     return message;
   },
 };
 
 function createBaseFileInfo(): FileInfo {
-  return { filename: '', startedAt: 0, endedAt: 0, duration: 0, size: 0, location: '' };
+  return { filename: "", startedAt: 0, endedAt: 0, duration: 0, size: 0, location: "" };
 }
 
 export const FileInfo = {
   encode(message: FileInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.filename !== undefined && message.filename !== '') {
+    if (message.filename !== undefined && message.filename !== "") {
       writer.uint32(10).string(message.filename);
     }
     if (message.startedAt !== undefined && message.startedAt !== 0) {
@@ -3104,7 +3012,7 @@ export const FileInfo = {
     if (message.size !== undefined && message.size !== 0) {
       writer.uint32(32).int64(message.size);
     }
-    if (message.location !== undefined && message.location !== '') {
+    if (message.location !== undefined && message.location !== "") {
       writer.uint32(42).string(message.location);
     }
     return writer;
@@ -3145,12 +3053,12 @@ export const FileInfo = {
 
   fromJSON(object: any): FileInfo {
     return {
-      filename: isSet(object.filename) ? String(object.filename) : '',
+      filename: isSet(object.filename) ? String(object.filename) : "",
       startedAt: isSet(object.startedAt) ? Number(object.startedAt) : 0,
       endedAt: isSet(object.endedAt) ? Number(object.endedAt) : 0,
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       size: isSet(object.size) ? Number(object.size) : 0,
-      location: isSet(object.location) ? String(object.location) : '',
+      location: isSet(object.location) ? String(object.location) : "",
     };
   },
 
@@ -3167,31 +3075,23 @@ export const FileInfo = {
 
   fromPartial<I extends Exact<DeepPartial<FileInfo>, I>>(object: I): FileInfo {
     const message = createBaseFileInfo();
-    message.filename = object.filename ?? '';
+    message.filename = object.filename ?? "";
     message.startedAt = object.startedAt ?? 0;
     message.endedAt = object.endedAt ?? 0;
     message.duration = object.duration ?? 0;
     message.size = object.size ?? 0;
-    message.location = object.location ?? '';
+    message.location = object.location ?? "";
     return message;
   },
 };
 
 function createBaseSegmentsInfo(): SegmentsInfo {
-  return {
-    playlistName: '',
-    duration: 0,
-    size: 0,
-    playlistLocation: '',
-    segmentCount: 0,
-    startedAt: 0,
-    endedAt: 0,
-  };
+  return { playlistName: "", duration: 0, size: 0, playlistLocation: "", segmentCount: 0, startedAt: 0, endedAt: 0 };
 }
 
 export const SegmentsInfo = {
   encode(message: SegmentsInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.playlistName !== undefined && message.playlistName !== '') {
+    if (message.playlistName !== undefined && message.playlistName !== "") {
       writer.uint32(10).string(message.playlistName);
     }
     if (message.duration !== undefined && message.duration !== 0) {
@@ -3200,7 +3100,7 @@ export const SegmentsInfo = {
     if (message.size !== undefined && message.size !== 0) {
       writer.uint32(24).int64(message.size);
     }
-    if (message.playlistLocation !== undefined && message.playlistLocation !== '') {
+    if (message.playlistLocation !== undefined && message.playlistLocation !== "") {
       writer.uint32(34).string(message.playlistLocation);
     }
     if (message.segmentCount !== undefined && message.segmentCount !== 0) {
@@ -3253,10 +3153,10 @@ export const SegmentsInfo = {
 
   fromJSON(object: any): SegmentsInfo {
     return {
-      playlistName: isSet(object.playlistName) ? String(object.playlistName) : '',
+      playlistName: isSet(object.playlistName) ? String(object.playlistName) : "",
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       size: isSet(object.size) ? Number(object.size) : 0,
-      playlistLocation: isSet(object.playlistLocation) ? String(object.playlistLocation) : '',
+      playlistLocation: isSet(object.playlistLocation) ? String(object.playlistLocation) : "",
       segmentCount: isSet(object.segmentCount) ? Number(object.segmentCount) : 0,
       startedAt: isSet(object.startedAt) ? Number(object.startedAt) : 0,
       endedAt: isSet(object.endedAt) ? Number(object.endedAt) : 0,
@@ -3277,10 +3177,10 @@ export const SegmentsInfo = {
 
   fromPartial<I extends Exact<DeepPartial<SegmentsInfo>, I>>(object: I): SegmentsInfo {
     const message = createBaseSegmentsInfo();
-    message.playlistName = object.playlistName ?? '';
+    message.playlistName = object.playlistName ?? "";
     message.duration = object.duration ?? 0;
     message.size = object.size ?? 0;
-    message.playlistLocation = object.playlistLocation ?? '';
+    message.playlistLocation = object.playlistLocation ?? "";
     message.segmentCount = object.segmentCount ?? 0;
     message.startedAt = object.startedAt ?? 0;
     message.endedAt = object.endedAt ?? 0;
@@ -3289,12 +3189,12 @@ export const SegmentsInfo = {
 };
 
 function createBaseAutoTrackEgress(): AutoTrackEgress {
-  return { filepath: '', disableManifest: false, s3: undefined, gcp: undefined, azure: undefined };
+  return { filepath: "", disableManifest: false, s3: undefined, gcp: undefined, azure: undefined };
 }
 
 export const AutoTrackEgress = {
   encode(message: AutoTrackEgress, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.filepath !== undefined && message.filepath !== '') {
+    if (message.filepath !== undefined && message.filepath !== "") {
       writer.uint32(10).string(message.filepath);
     }
     if (message.disableManifest === true) {
@@ -3344,7 +3244,7 @@ export const AutoTrackEgress = {
 
   fromJSON(object: any): AutoTrackEgress {
     return {
-      filepath: isSet(object.filepath) ? String(object.filepath) : '',
+      filepath: isSet(object.filepath) ? String(object.filepath) : "",
       disableManifest: isSet(object.disableManifest) ? Boolean(object.disableManifest) : false,
       s3: isSet(object.s3) ? S3Upload.fromJSON(object.s3) : undefined,
       gcp: isSet(object.gcp) ? GCPUpload.fromJSON(object.gcp) : undefined,
@@ -3357,27 +3257,20 @@ export const AutoTrackEgress = {
     message.filepath !== undefined && (obj.filepath = message.filepath);
     message.disableManifest !== undefined && (obj.disableManifest = message.disableManifest);
     message.s3 !== undefined && (obj.s3 = message.s3 ? S3Upload.toJSON(message.s3) : undefined);
-    message.gcp !== undefined &&
-      (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
-    message.azure !== undefined &&
-      (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
+    message.gcp !== undefined && (obj.gcp = message.gcp ? GCPUpload.toJSON(message.gcp) : undefined);
+    message.azure !== undefined && (obj.azure = message.azure ? AzureBlobUpload.toJSON(message.azure) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<AutoTrackEgress>, I>>(object: I): AutoTrackEgress {
     const message = createBaseAutoTrackEgress();
-    message.filepath = object.filepath ?? '';
+    message.filepath = object.filepath ?? "";
     message.disableManifest = object.disableManifest ?? false;
-    message.s3 =
-      object.s3 !== undefined && object.s3 !== null ? S3Upload.fromPartial(object.s3) : undefined;
-    message.gcp =
-      object.gcp !== undefined && object.gcp !== null
-        ? GCPUpload.fromPartial(object.gcp)
-        : undefined;
-    message.azure =
-      object.azure !== undefined && object.azure !== null
-        ? AzureBlobUpload.fromPartial(object.azure)
-        : undefined;
+    message.s3 = (object.s3 !== undefined && object.s3 !== null) ? S3Upload.fromPartial(object.s3) : undefined;
+    message.gcp = (object.gcp !== undefined && object.gcp !== null) ? GCPUpload.fromPartial(object.gcp) : undefined;
+    message.azure = (object.azure !== undefined && object.azure !== null)
+      ? AzureBlobUpload.fromPartial(object.azure)
+      : undefined;
     return message;
   },
 };
@@ -3402,33 +3295,35 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
 })();
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }
@@ -3439,7 +3334,7 @@ if (_m0.util.Long !== Long) {
 }
 
 function isObject(value: any): boolean {
-  return typeof value === 'object' && value !== null;
+  return typeof value === "object" && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/src/proto/livekit_ingress.ts
+++ b/src/proto/livekit_ingress.ts
@@ -1,21 +1,21 @@
 /* eslint-disable */
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import {
-  TrackSource,
   AudioCodec,
-  VideoCodec,
-  VideoLayer,
-  TrackInfo,
-  trackSourceFromJSON,
-  trackSourceToJSON,
   audioCodecFromJSON,
   audioCodecToJSON,
+  TrackInfo,
+  TrackSource,
+  trackSourceFromJSON,
+  trackSourceToJSON,
+  VideoCodec,
   videoCodecFromJSON,
   videoCodecToJSON,
-} from './livekit_models';
+  VideoLayer,
+} from "./livekit_models";
 
-export const protobufPackage = 'livekit';
+export const protobufPackage = "livekit";
 
 export enum IngressInput {
   RTMP_INPUT = 0,
@@ -31,13 +31,13 @@ export enum IngressInput {
 export function ingressInputFromJSON(object: any): IngressInput {
   switch (object) {
     case 0:
-    case 'RTMP_INPUT':
+    case "RTMP_INPUT":
       return IngressInput.RTMP_INPUT;
     case 1:
-    case 'WHIP_INPUT':
+    case "WHIP_INPUT":
       return IngressInput.WHIP_INPUT;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return IngressInput.UNRECOGNIZED;
   }
@@ -46,11 +46,12 @@ export function ingressInputFromJSON(object: any): IngressInput {
 export function ingressInputToJSON(object: IngressInput): string {
   switch (object) {
     case IngressInput.RTMP_INPUT:
-      return 'RTMP_INPUT';
+      return "RTMP_INPUT";
     case IngressInput.WHIP_INPUT:
-      return 'WHIP_INPUT';
+      return "WHIP_INPUT";
+    case IngressInput.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -65,13 +66,13 @@ export enum IngressAudioEncodingPreset {
 export function ingressAudioEncodingPresetFromJSON(object: any): IngressAudioEncodingPreset {
   switch (object) {
     case 0:
-    case 'OPUS_STEREO_96KBPS':
+    case "OPUS_STEREO_96KBPS":
       return IngressAudioEncodingPreset.OPUS_STEREO_96KBPS;
     case 1:
-    case 'OPUS_MONO_64KBS':
+    case "OPUS_MONO_64KBS":
       return IngressAudioEncodingPreset.OPUS_MONO_64KBS;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return IngressAudioEncodingPreset.UNRECOGNIZED;
   }
@@ -80,11 +81,12 @@ export function ingressAudioEncodingPresetFromJSON(object: any): IngressAudioEnc
 export function ingressAudioEncodingPresetToJSON(object: IngressAudioEncodingPreset): string {
   switch (object) {
     case IngressAudioEncodingPreset.OPUS_STEREO_96KBPS:
-      return 'OPUS_STEREO_96KBPS';
+      return "OPUS_STEREO_96KBPS";
     case IngressAudioEncodingPreset.OPUS_MONO_64KBS:
-      return 'OPUS_MONO_64KBS';
+      return "OPUS_MONO_64KBS";
+    case IngressAudioEncodingPreset.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -105,22 +107,22 @@ export enum IngressVideoEncodingPreset {
 export function ingressVideoEncodingPresetFromJSON(object: any): IngressVideoEncodingPreset {
   switch (object) {
     case 0:
-    case 'H264_720P_30FPS_3_LAYERS':
+    case "H264_720P_30FPS_3_LAYERS":
       return IngressVideoEncodingPreset.H264_720P_30FPS_3_LAYERS;
     case 1:
-    case 'H264_1080P_30FPS_3_LAYERS':
+    case "H264_1080P_30FPS_3_LAYERS":
       return IngressVideoEncodingPreset.H264_1080P_30FPS_3_LAYERS;
     case 2:
-    case 'H264_540P_25FPS_2_LAYERS':
+    case "H264_540P_25FPS_2_LAYERS":
       return IngressVideoEncodingPreset.H264_540P_25FPS_2_LAYERS;
     case 3:
-    case 'H264_720P_30FPS_1_LAYER':
+    case "H264_720P_30FPS_1_LAYER":
       return IngressVideoEncodingPreset.H264_720P_30FPS_1_LAYER;
     case 4:
-    case 'H264_1080P_30FPS_1_LAYER':
+    case "H264_1080P_30FPS_1_LAYER":
       return IngressVideoEncodingPreset.H264_1080P_30FPS_1_LAYER;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return IngressVideoEncodingPreset.UNRECOGNIZED;
   }
@@ -129,17 +131,18 @@ export function ingressVideoEncodingPresetFromJSON(object: any): IngressVideoEnc
 export function ingressVideoEncodingPresetToJSON(object: IngressVideoEncodingPreset): string {
   switch (object) {
     case IngressVideoEncodingPreset.H264_720P_30FPS_3_LAYERS:
-      return 'H264_720P_30FPS_3_LAYERS';
+      return "H264_720P_30FPS_3_LAYERS";
     case IngressVideoEncodingPreset.H264_1080P_30FPS_3_LAYERS:
-      return 'H264_1080P_30FPS_3_LAYERS';
+      return "H264_1080P_30FPS_3_LAYERS";
     case IngressVideoEncodingPreset.H264_540P_25FPS_2_LAYERS:
-      return 'H264_540P_25FPS_2_LAYERS';
+      return "H264_540P_25FPS_2_LAYERS";
     case IngressVideoEncodingPreset.H264_720P_30FPS_1_LAYER:
-      return 'H264_720P_30FPS_1_LAYER';
+      return "H264_720P_30FPS_1_LAYER";
     case IngressVideoEncodingPreset.H264_1080P_30FPS_1_LAYER:
-      return 'H264_1080P_30FPS_1_LAYER';
+      return "H264_1080P_30FPS_1_LAYER";
+    case IngressVideoEncodingPreset.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -221,6 +224,7 @@ export interface IngressState {
   roomId?: string;
   startedAt?: number;
   endedAt?: number;
+  resourceId?: string;
   tracks?: TrackInfo[];
 }
 
@@ -235,19 +239,19 @@ export enum IngressState_Status {
 export function ingressState_StatusFromJSON(object: any): IngressState_Status {
   switch (object) {
     case 0:
-    case 'ENDPOINT_INACTIVE':
+    case "ENDPOINT_INACTIVE":
       return IngressState_Status.ENDPOINT_INACTIVE;
     case 1:
-    case 'ENDPOINT_BUFFERING':
+    case "ENDPOINT_BUFFERING":
       return IngressState_Status.ENDPOINT_BUFFERING;
     case 2:
-    case 'ENDPOINT_PUBLISHING':
+    case "ENDPOINT_PUBLISHING":
       return IngressState_Status.ENDPOINT_PUBLISHING;
     case 3:
-    case 'ENDPOINT_ERROR':
+    case "ENDPOINT_ERROR":
       return IngressState_Status.ENDPOINT_ERROR;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return IngressState_Status.UNRECOGNIZED;
   }
@@ -256,15 +260,16 @@ export function ingressState_StatusFromJSON(object: any): IngressState_Status {
 export function ingressState_StatusToJSON(object: IngressState_Status): string {
   switch (object) {
     case IngressState_Status.ENDPOINT_INACTIVE:
-      return 'ENDPOINT_INACTIVE';
+      return "ENDPOINT_INACTIVE";
     case IngressState_Status.ENDPOINT_BUFFERING:
-      return 'ENDPOINT_BUFFERING';
+      return "ENDPOINT_BUFFERING";
     case IngressState_Status.ENDPOINT_PUBLISHING:
-      return 'ENDPOINT_PUBLISHING';
+      return "ENDPOINT_PUBLISHING";
     case IngressState_Status.ENDPOINT_ERROR:
-      return 'ENDPOINT_ERROR';
+      return "ENDPOINT_ERROR";
+    case IngressState_Status.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -310,10 +315,10 @@ export interface DeleteIngressRequest {
 function createBaseCreateIngressRequest(): CreateIngressRequest {
   return {
     inputType: 0,
-    name: '',
-    roomName: '',
-    participantIdentity: '',
-    participantName: '',
+    name: "",
+    roomName: "",
+    participantIdentity: "",
+    participantName: "",
     bypassTranscoding: false,
     audio: undefined,
     video: undefined,
@@ -325,16 +330,16 @@ export const CreateIngressRequest = {
     if (message.inputType !== undefined && message.inputType !== 0) {
       writer.uint32(8).int32(message.inputType);
     }
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(18).string(message.name);
     }
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(26).string(message.roomName);
     }
-    if (message.participantIdentity !== undefined && message.participantIdentity !== '') {
+    if (message.participantIdentity !== undefined && message.participantIdentity !== "") {
       writer.uint32(34).string(message.participantIdentity);
     }
-    if (message.participantName !== undefined && message.participantName !== '') {
+    if (message.participantName !== undefined && message.participantName !== "") {
       writer.uint32(42).string(message.participantName);
     }
     if (message.bypassTranscoding === true) {
@@ -391,15 +396,11 @@ export const CreateIngressRequest = {
   fromJSON(object: any): CreateIngressRequest {
     return {
       inputType: isSet(object.inputType) ? ingressInputFromJSON(object.inputType) : 0,
-      name: isSet(object.name) ? String(object.name) : '',
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      participantIdentity: isSet(object.participantIdentity)
-        ? String(object.participantIdentity)
-        : '',
-      participantName: isSet(object.participantName) ? String(object.participantName) : '',
-      bypassTranscoding: isSet(object.bypassTranscoding)
-        ? Boolean(object.bypassTranscoding)
-        : false,
+      name: isSet(object.name) ? String(object.name) : "",
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      participantIdentity: isSet(object.participantIdentity) ? String(object.participantIdentity) : "",
+      participantName: isSet(object.participantName) ? String(object.participantName) : "",
+      bypassTranscoding: isSet(object.bypassTranscoding) ? Boolean(object.bypassTranscoding) : false,
       audio: isSet(object.audio) ? IngressAudioOptions.fromJSON(object.audio) : undefined,
       video: isSet(object.video) ? IngressVideoOptions.fromJSON(object.video) : undefined,
     };
@@ -410,46 +411,39 @@ export const CreateIngressRequest = {
     message.inputType !== undefined && (obj.inputType = ingressInputToJSON(message.inputType));
     message.name !== undefined && (obj.name = message.name);
     message.roomName !== undefined && (obj.roomName = message.roomName);
-    message.participantIdentity !== undefined &&
-      (obj.participantIdentity = message.participantIdentity);
+    message.participantIdentity !== undefined && (obj.participantIdentity = message.participantIdentity);
     message.participantName !== undefined && (obj.participantName = message.participantName);
     message.bypassTranscoding !== undefined && (obj.bypassTranscoding = message.bypassTranscoding);
-    message.audio !== undefined &&
-      (obj.audio = message.audio ? IngressAudioOptions.toJSON(message.audio) : undefined);
-    message.video !== undefined &&
-      (obj.video = message.video ? IngressVideoOptions.toJSON(message.video) : undefined);
+    message.audio !== undefined && (obj.audio = message.audio ? IngressAudioOptions.toJSON(message.audio) : undefined);
+    message.video !== undefined && (obj.video = message.video ? IngressVideoOptions.toJSON(message.video) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<CreateIngressRequest>, I>>(
-    object: I,
-  ): CreateIngressRequest {
+  fromPartial<I extends Exact<DeepPartial<CreateIngressRequest>, I>>(object: I): CreateIngressRequest {
     const message = createBaseCreateIngressRequest();
     message.inputType = object.inputType ?? 0;
-    message.name = object.name ?? '';
-    message.roomName = object.roomName ?? '';
-    message.participantIdentity = object.participantIdentity ?? '';
-    message.participantName = object.participantName ?? '';
+    message.name = object.name ?? "";
+    message.roomName = object.roomName ?? "";
+    message.participantIdentity = object.participantIdentity ?? "";
+    message.participantName = object.participantName ?? "";
     message.bypassTranscoding = object.bypassTranscoding ?? false;
-    message.audio =
-      object.audio !== undefined && object.audio !== null
-        ? IngressAudioOptions.fromPartial(object.audio)
-        : undefined;
-    message.video =
-      object.video !== undefined && object.video !== null
-        ? IngressVideoOptions.fromPartial(object.video)
-        : undefined;
+    message.audio = (object.audio !== undefined && object.audio !== null)
+      ? IngressAudioOptions.fromPartial(object.audio)
+      : undefined;
+    message.video = (object.video !== undefined && object.video !== null)
+      ? IngressVideoOptions.fromPartial(object.video)
+      : undefined;
     return message;
   },
 };
 
 function createBaseIngressAudioOptions(): IngressAudioOptions {
-  return { name: '', source: 0, preset: undefined, options: undefined };
+  return { name: "", source: 0, preset: undefined, options: undefined };
 }
 
 export const IngressAudioOptions = {
   encode(message: IngressAudioOptions, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
     }
     if (message.source !== undefined && message.source !== 0) {
@@ -493,12 +487,10 @@ export const IngressAudioOptions = {
 
   fromJSON(object: any): IngressAudioOptions {
     return {
-      name: isSet(object.name) ? String(object.name) : '',
+      name: isSet(object.name) ? String(object.name) : "",
       source: isSet(object.source) ? trackSourceFromJSON(object.source) : 0,
       preset: isSet(object.preset) ? ingressAudioEncodingPresetFromJSON(object.preset) : undefined,
-      options: isSet(object.options)
-        ? IngressAudioEncodingOptions.fromJSON(object.options)
-        : undefined,
+      options: isSet(object.options) ? IngressAudioEncodingOptions.fromJSON(object.options) : undefined,
     };
   },
 
@@ -507,39 +499,31 @@ export const IngressAudioOptions = {
     message.name !== undefined && (obj.name = message.name);
     message.source !== undefined && (obj.source = trackSourceToJSON(message.source));
     message.preset !== undefined &&
-      (obj.preset =
-        message.preset !== undefined
-          ? ingressAudioEncodingPresetToJSON(message.preset)
-          : undefined);
+      (obj.preset = message.preset !== undefined ? ingressAudioEncodingPresetToJSON(message.preset) : undefined);
     message.options !== undefined &&
-      (obj.options = message.options
-        ? IngressAudioEncodingOptions.toJSON(message.options)
-        : undefined);
+      (obj.options = message.options ? IngressAudioEncodingOptions.toJSON(message.options) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<IngressAudioOptions>, I>>(
-    object: I,
-  ): IngressAudioOptions {
+  fromPartial<I extends Exact<DeepPartial<IngressAudioOptions>, I>>(object: I): IngressAudioOptions {
     const message = createBaseIngressAudioOptions();
-    message.name = object.name ?? '';
+    message.name = object.name ?? "";
     message.source = object.source ?? 0;
     message.preset = object.preset ?? undefined;
-    message.options =
-      object.options !== undefined && object.options !== null
-        ? IngressAudioEncodingOptions.fromPartial(object.options)
-        : undefined;
+    message.options = (object.options !== undefined && object.options !== null)
+      ? IngressAudioEncodingOptions.fromPartial(object.options)
+      : undefined;
     return message;
   },
 };
 
 function createBaseIngressVideoOptions(): IngressVideoOptions {
-  return { name: '', source: 0, preset: undefined, options: undefined };
+  return { name: "", source: 0, preset: undefined, options: undefined };
 }
 
 export const IngressVideoOptions = {
   encode(message: IngressVideoOptions, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
     }
     if (message.source !== undefined && message.source !== 0) {
@@ -583,12 +567,10 @@ export const IngressVideoOptions = {
 
   fromJSON(object: any): IngressVideoOptions {
     return {
-      name: isSet(object.name) ? String(object.name) : '',
+      name: isSet(object.name) ? String(object.name) : "",
       source: isSet(object.source) ? trackSourceFromJSON(object.source) : 0,
       preset: isSet(object.preset) ? ingressVideoEncodingPresetFromJSON(object.preset) : undefined,
-      options: isSet(object.options)
-        ? IngressVideoEncodingOptions.fromJSON(object.options)
-        : undefined,
+      options: isSet(object.options) ? IngressVideoEncodingOptions.fromJSON(object.options) : undefined,
     };
   },
 
@@ -597,28 +579,20 @@ export const IngressVideoOptions = {
     message.name !== undefined && (obj.name = message.name);
     message.source !== undefined && (obj.source = trackSourceToJSON(message.source));
     message.preset !== undefined &&
-      (obj.preset =
-        message.preset !== undefined
-          ? ingressVideoEncodingPresetToJSON(message.preset)
-          : undefined);
+      (obj.preset = message.preset !== undefined ? ingressVideoEncodingPresetToJSON(message.preset) : undefined);
     message.options !== undefined &&
-      (obj.options = message.options
-        ? IngressVideoEncodingOptions.toJSON(message.options)
-        : undefined);
+      (obj.options = message.options ? IngressVideoEncodingOptions.toJSON(message.options) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<IngressVideoOptions>, I>>(
-    object: I,
-  ): IngressVideoOptions {
+  fromPartial<I extends Exact<DeepPartial<IngressVideoOptions>, I>>(object: I): IngressVideoOptions {
     const message = createBaseIngressVideoOptions();
-    message.name = object.name ?? '';
+    message.name = object.name ?? "";
     message.source = object.source ?? 0;
     message.preset = object.preset ?? undefined;
-    message.options =
-      object.options !== undefined && object.options !== null
-        ? IngressVideoEncodingOptions.fromPartial(object.options)
-        : undefined;
+    message.options = (object.options !== undefined && object.options !== null)
+      ? IngressVideoEncodingOptions.fromPartial(object.options)
+      : undefined;
     return message;
   },
 };
@@ -628,10 +602,7 @@ function createBaseIngressAudioEncodingOptions(): IngressAudioEncodingOptions {
 }
 
 export const IngressAudioEncodingOptions = {
-  encode(
-    message: IngressAudioEncodingOptions,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
+  encode(message: IngressAudioEncodingOptions, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.audioCodec !== undefined && message.audioCodec !== 0) {
       writer.uint32(8).int32(message.audioCodec);
     }
@@ -692,9 +663,7 @@ export const IngressAudioEncodingOptions = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<IngressAudioEncodingOptions>, I>>(
-    object: I,
-  ): IngressAudioEncodingOptions {
+  fromPartial<I extends Exact<DeepPartial<IngressAudioEncodingOptions>, I>>(object: I): IngressAudioEncodingOptions {
     const message = createBaseIngressAudioEncodingOptions();
     message.audioCodec = object.audioCodec ?? 0;
     message.bitrate = object.bitrate ?? 0;
@@ -709,10 +678,7 @@ function createBaseIngressVideoEncodingOptions(): IngressVideoEncodingOptions {
 }
 
 export const IngressVideoEncodingOptions = {
-  encode(
-    message: IngressVideoEncodingOptions,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
+  encode(message: IngressVideoEncodingOptions, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.videoCodec !== undefined && message.videoCodec !== 0) {
       writer.uint32(8).int32(message.videoCodec);
     }
@@ -755,9 +721,7 @@ export const IngressVideoEncodingOptions = {
     return {
       videoCodec: isSet(object.videoCodec) ? videoCodecFromJSON(object.videoCodec) : 0,
       frameRate: isSet(object.frameRate) ? Number(object.frameRate) : 0,
-      layers: Array.isArray(object?.layers)
-        ? object.layers.map((e: any) => VideoLayer.fromJSON(e))
-        : [],
+      layers: Array.isArray(object?.layers) ? object.layers.map((e: any) => VideoLayer.fromJSON(e)) : [],
     };
   },
 
@@ -766,16 +730,14 @@ export const IngressVideoEncodingOptions = {
     message.videoCodec !== undefined && (obj.videoCodec = videoCodecToJSON(message.videoCodec));
     message.frameRate !== undefined && (obj.frameRate = message.frameRate);
     if (message.layers) {
-      obj.layers = message.layers.map((e) => (e ? VideoLayer.toJSON(e) : undefined));
+      obj.layers = message.layers.map((e) => e ? VideoLayer.toJSON(e) : undefined);
     } else {
       obj.layers = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<IngressVideoEncodingOptions>, I>>(
-    object: I,
-  ): IngressVideoEncodingOptions {
+  fromPartial<I extends Exact<DeepPartial<IngressVideoEncodingOptions>, I>>(object: I): IngressVideoEncodingOptions {
     const message = createBaseIngressVideoEncodingOptions();
     message.videoCodec = object.videoCodec ?? 0;
     message.frameRate = object.frameRate ?? 0;
@@ -786,17 +748,17 @@ export const IngressVideoEncodingOptions = {
 
 function createBaseIngressInfo(): IngressInfo {
   return {
-    ingressId: '',
-    name: '',
-    streamKey: '',
-    url: '',
+    ingressId: "",
+    name: "",
+    streamKey: "",
+    url: "",
     inputType: 0,
     bypassTranscoding: false,
     audio: undefined,
     video: undefined,
-    roomName: '',
-    participantIdentity: '',
-    participantName: '',
+    roomName: "",
+    participantIdentity: "",
+    participantName: "",
     reusable: false,
     state: undefined,
   };
@@ -804,16 +766,16 @@ function createBaseIngressInfo(): IngressInfo {
 
 export const IngressInfo = {
   encode(message: IngressInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.ingressId !== undefined && message.ingressId !== '') {
+    if (message.ingressId !== undefined && message.ingressId !== "") {
       writer.uint32(10).string(message.ingressId);
     }
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(18).string(message.name);
     }
-    if (message.streamKey !== undefined && message.streamKey !== '') {
+    if (message.streamKey !== undefined && message.streamKey !== "") {
       writer.uint32(26).string(message.streamKey);
     }
-    if (message.url !== undefined && message.url !== '') {
+    if (message.url !== undefined && message.url !== "") {
       writer.uint32(34).string(message.url);
     }
     if (message.inputType !== undefined && message.inputType !== 0) {
@@ -828,13 +790,13 @@ export const IngressInfo = {
     if (message.video !== undefined) {
       IngressVideoOptions.encode(message.video, writer.uint32(58).fork()).ldelim();
     }
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(66).string(message.roomName);
     }
-    if (message.participantIdentity !== undefined && message.participantIdentity !== '') {
+    if (message.participantIdentity !== undefined && message.participantIdentity !== "") {
       writer.uint32(74).string(message.participantIdentity);
     }
-    if (message.participantName !== undefined && message.participantName !== '') {
+    if (message.participantName !== undefined && message.participantName !== "") {
       writer.uint32(82).string(message.participantName);
     }
     if (message.reusable === true) {
@@ -902,21 +864,17 @@ export const IngressInfo = {
 
   fromJSON(object: any): IngressInfo {
     return {
-      ingressId: isSet(object.ingressId) ? String(object.ingressId) : '',
-      name: isSet(object.name) ? String(object.name) : '',
-      streamKey: isSet(object.streamKey) ? String(object.streamKey) : '',
-      url: isSet(object.url) ? String(object.url) : '',
+      ingressId: isSet(object.ingressId) ? String(object.ingressId) : "",
+      name: isSet(object.name) ? String(object.name) : "",
+      streamKey: isSet(object.streamKey) ? String(object.streamKey) : "",
+      url: isSet(object.url) ? String(object.url) : "",
       inputType: isSet(object.inputType) ? ingressInputFromJSON(object.inputType) : 0,
-      bypassTranscoding: isSet(object.bypassTranscoding)
-        ? Boolean(object.bypassTranscoding)
-        : false,
+      bypassTranscoding: isSet(object.bypassTranscoding) ? Boolean(object.bypassTranscoding) : false,
       audio: isSet(object.audio) ? IngressAudioOptions.fromJSON(object.audio) : undefined,
       video: isSet(object.video) ? IngressVideoOptions.fromJSON(object.video) : undefined,
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      participantIdentity: isSet(object.participantIdentity)
-        ? String(object.participantIdentity)
-        : '',
-      participantName: isSet(object.participantName) ? String(object.participantName) : '',
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      participantIdentity: isSet(object.participantIdentity) ? String(object.participantIdentity) : "",
+      participantName: isSet(object.participantName) ? String(object.participantName) : "",
       reusable: isSet(object.reusable) ? Boolean(object.reusable) : false,
       state: isSet(object.state) ? IngressState.fromJSON(object.state) : undefined,
     };
@@ -930,44 +888,37 @@ export const IngressInfo = {
     message.url !== undefined && (obj.url = message.url);
     message.inputType !== undefined && (obj.inputType = ingressInputToJSON(message.inputType));
     message.bypassTranscoding !== undefined && (obj.bypassTranscoding = message.bypassTranscoding);
-    message.audio !== undefined &&
-      (obj.audio = message.audio ? IngressAudioOptions.toJSON(message.audio) : undefined);
-    message.video !== undefined &&
-      (obj.video = message.video ? IngressVideoOptions.toJSON(message.video) : undefined);
+    message.audio !== undefined && (obj.audio = message.audio ? IngressAudioOptions.toJSON(message.audio) : undefined);
+    message.video !== undefined && (obj.video = message.video ? IngressVideoOptions.toJSON(message.video) : undefined);
     message.roomName !== undefined && (obj.roomName = message.roomName);
-    message.participantIdentity !== undefined &&
-      (obj.participantIdentity = message.participantIdentity);
+    message.participantIdentity !== undefined && (obj.participantIdentity = message.participantIdentity);
     message.participantName !== undefined && (obj.participantName = message.participantName);
     message.reusable !== undefined && (obj.reusable = message.reusable);
-    message.state !== undefined &&
-      (obj.state = message.state ? IngressState.toJSON(message.state) : undefined);
+    message.state !== undefined && (obj.state = message.state ? IngressState.toJSON(message.state) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<IngressInfo>, I>>(object: I): IngressInfo {
     const message = createBaseIngressInfo();
-    message.ingressId = object.ingressId ?? '';
-    message.name = object.name ?? '';
-    message.streamKey = object.streamKey ?? '';
-    message.url = object.url ?? '';
+    message.ingressId = object.ingressId ?? "";
+    message.name = object.name ?? "";
+    message.streamKey = object.streamKey ?? "";
+    message.url = object.url ?? "";
     message.inputType = object.inputType ?? 0;
     message.bypassTranscoding = object.bypassTranscoding ?? false;
-    message.audio =
-      object.audio !== undefined && object.audio !== null
-        ? IngressAudioOptions.fromPartial(object.audio)
-        : undefined;
-    message.video =
-      object.video !== undefined && object.video !== null
-        ? IngressVideoOptions.fromPartial(object.video)
-        : undefined;
-    message.roomName = object.roomName ?? '';
-    message.participantIdentity = object.participantIdentity ?? '';
-    message.participantName = object.participantName ?? '';
+    message.audio = (object.audio !== undefined && object.audio !== null)
+      ? IngressAudioOptions.fromPartial(object.audio)
+      : undefined;
+    message.video = (object.video !== undefined && object.video !== null)
+      ? IngressVideoOptions.fromPartial(object.video)
+      : undefined;
+    message.roomName = object.roomName ?? "";
+    message.participantIdentity = object.participantIdentity ?? "";
+    message.participantName = object.participantName ?? "";
     message.reusable = object.reusable ?? false;
-    message.state =
-      object.state !== undefined && object.state !== null
-        ? IngressState.fromPartial(object.state)
-        : undefined;
+    message.state = (object.state !== undefined && object.state !== null)
+      ? IngressState.fromPartial(object.state)
+      : undefined;
     return message;
   },
 };
@@ -975,12 +926,13 @@ export const IngressInfo = {
 function createBaseIngressState(): IngressState {
   return {
     status: 0,
-    error: '',
+    error: "",
     video: undefined,
     audio: undefined,
-    roomId: '',
+    roomId: "",
     startedAt: 0,
     endedAt: 0,
+    resourceId: "",
     tracks: [],
   };
 }
@@ -990,7 +942,7 @@ export const IngressState = {
     if (message.status !== undefined && message.status !== 0) {
       writer.uint32(8).int32(message.status);
     }
-    if (message.error !== undefined && message.error !== '') {
+    if (message.error !== undefined && message.error !== "") {
       writer.uint32(18).string(message.error);
     }
     if (message.video !== undefined) {
@@ -999,7 +951,7 @@ export const IngressState = {
     if (message.audio !== undefined) {
       InputAudioState.encode(message.audio, writer.uint32(34).fork()).ldelim();
     }
-    if (message.roomId !== undefined && message.roomId !== '') {
+    if (message.roomId !== undefined && message.roomId !== "") {
       writer.uint32(42).string(message.roomId);
     }
     if (message.startedAt !== undefined && message.startedAt !== 0) {
@@ -1007,6 +959,9 @@ export const IngressState = {
     }
     if (message.endedAt !== undefined && message.endedAt !== 0) {
       writer.uint32(64).int64(message.endedAt);
+    }
+    if (message.resourceId !== undefined && message.resourceId !== "") {
+      writer.uint32(74).string(message.resourceId);
     }
     if (message.tracks !== undefined && message.tracks.length !== 0) {
       for (const v of message.tracks) {
@@ -1044,6 +999,9 @@ export const IngressState = {
         case 8:
           message.endedAt = longToNumber(reader.int64() as Long);
           break;
+        case 9:
+          message.resourceId = reader.string();
+          break;
         case 6:
           message.tracks!.push(TrackInfo.decode(reader, reader.uint32()));
           break;
@@ -1058,15 +1016,14 @@ export const IngressState = {
   fromJSON(object: any): IngressState {
     return {
       status: isSet(object.status) ? ingressState_StatusFromJSON(object.status) : 0,
-      error: isSet(object.error) ? String(object.error) : '',
+      error: isSet(object.error) ? String(object.error) : "",
       video: isSet(object.video) ? InputVideoState.fromJSON(object.video) : undefined,
       audio: isSet(object.audio) ? InputAudioState.fromJSON(object.audio) : undefined,
-      roomId: isSet(object.roomId) ? String(object.roomId) : '',
+      roomId: isSet(object.roomId) ? String(object.roomId) : "",
       startedAt: isSet(object.startedAt) ? Number(object.startedAt) : 0,
       endedAt: isSet(object.endedAt) ? Number(object.endedAt) : 0,
-      tracks: Array.isArray(object?.tracks)
-        ? object.tracks.map((e: any) => TrackInfo.fromJSON(e))
-        : [],
+      resourceId: isSet(object.resourceId) ? String(object.resourceId) : "",
+      tracks: Array.isArray(object?.tracks) ? object.tracks.map((e: any) => TrackInfo.fromJSON(e)) : [],
     };
   },
 
@@ -1074,15 +1031,14 @@ export const IngressState = {
     const obj: any = {};
     message.status !== undefined && (obj.status = ingressState_StatusToJSON(message.status));
     message.error !== undefined && (obj.error = message.error);
-    message.video !== undefined &&
-      (obj.video = message.video ? InputVideoState.toJSON(message.video) : undefined);
-    message.audio !== undefined &&
-      (obj.audio = message.audio ? InputAudioState.toJSON(message.audio) : undefined);
+    message.video !== undefined && (obj.video = message.video ? InputVideoState.toJSON(message.video) : undefined);
+    message.audio !== undefined && (obj.audio = message.audio ? InputAudioState.toJSON(message.audio) : undefined);
     message.roomId !== undefined && (obj.roomId = message.roomId);
     message.startedAt !== undefined && (obj.startedAt = Math.round(message.startedAt));
     message.endedAt !== undefined && (obj.endedAt = Math.round(message.endedAt));
+    message.resourceId !== undefined && (obj.resourceId = message.resourceId);
     if (message.tracks) {
-      obj.tracks = message.tracks.map((e) => (e ? TrackInfo.toJSON(e) : undefined));
+      obj.tracks = message.tracks.map((e) => e ? TrackInfo.toJSON(e) : undefined);
     } else {
       obj.tracks = [];
     }
@@ -1092,30 +1048,29 @@ export const IngressState = {
   fromPartial<I extends Exact<DeepPartial<IngressState>, I>>(object: I): IngressState {
     const message = createBaseIngressState();
     message.status = object.status ?? 0;
-    message.error = object.error ?? '';
-    message.video =
-      object.video !== undefined && object.video !== null
-        ? InputVideoState.fromPartial(object.video)
-        : undefined;
-    message.audio =
-      object.audio !== undefined && object.audio !== null
-        ? InputAudioState.fromPartial(object.audio)
-        : undefined;
-    message.roomId = object.roomId ?? '';
+    message.error = object.error ?? "";
+    message.video = (object.video !== undefined && object.video !== null)
+      ? InputVideoState.fromPartial(object.video)
+      : undefined;
+    message.audio = (object.audio !== undefined && object.audio !== null)
+      ? InputAudioState.fromPartial(object.audio)
+      : undefined;
+    message.roomId = object.roomId ?? "";
     message.startedAt = object.startedAt ?? 0;
     message.endedAt = object.endedAt ?? 0;
+    message.resourceId = object.resourceId ?? "";
     message.tracks = object.tracks?.map((e) => TrackInfo.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseInputVideoState(): InputVideoState {
-  return { mimeType: '', width: 0, height: 0, framerate: 0 };
+  return { mimeType: "", width: 0, height: 0, framerate: 0 };
 }
 
 export const InputVideoState = {
   encode(message: InputVideoState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.mimeType !== undefined && message.mimeType !== '') {
+    if (message.mimeType !== undefined && message.mimeType !== "") {
       writer.uint32(10).string(message.mimeType);
     }
     if (message.width !== undefined && message.width !== 0) {
@@ -1125,7 +1080,7 @@ export const InputVideoState = {
       writer.uint32(32).uint32(message.height);
     }
     if (message.framerate !== undefined && message.framerate !== 0) {
-      writer.uint32(40).uint32(message.framerate);
+      writer.uint32(41).double(message.framerate);
     }
     return writer;
   },
@@ -1147,7 +1102,7 @@ export const InputVideoState = {
           message.height = reader.uint32();
           break;
         case 5:
-          message.framerate = reader.uint32();
+          message.framerate = reader.double();
           break;
         default:
           reader.skipType(tag & 7);
@@ -1159,7 +1114,7 @@ export const InputVideoState = {
 
   fromJSON(object: any): InputVideoState {
     return {
-      mimeType: isSet(object.mimeType) ? String(object.mimeType) : '',
+      mimeType: isSet(object.mimeType) ? String(object.mimeType) : "",
       width: isSet(object.width) ? Number(object.width) : 0,
       height: isSet(object.height) ? Number(object.height) : 0,
       framerate: isSet(object.framerate) ? Number(object.framerate) : 0,
@@ -1171,13 +1126,13 @@ export const InputVideoState = {
     message.mimeType !== undefined && (obj.mimeType = message.mimeType);
     message.width !== undefined && (obj.width = Math.round(message.width));
     message.height !== undefined && (obj.height = Math.round(message.height));
-    message.framerate !== undefined && (obj.framerate = Math.round(message.framerate));
+    message.framerate !== undefined && (obj.framerate = message.framerate);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<InputVideoState>, I>>(object: I): InputVideoState {
     const message = createBaseInputVideoState();
-    message.mimeType = object.mimeType ?? '';
+    message.mimeType = object.mimeType ?? "";
     message.width = object.width ?? 0;
     message.height = object.height ?? 0;
     message.framerate = object.framerate ?? 0;
@@ -1186,12 +1141,12 @@ export const InputVideoState = {
 };
 
 function createBaseInputAudioState(): InputAudioState {
-  return { mimeType: '', channels: 0, sampleRate: 0 };
+  return { mimeType: "", channels: 0, sampleRate: 0 };
 }
 
 export const InputAudioState = {
   encode(message: InputAudioState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.mimeType !== undefined && message.mimeType !== '') {
+    if (message.mimeType !== undefined && message.mimeType !== "") {
       writer.uint32(10).string(message.mimeType);
     }
     if (message.channels !== undefined && message.channels !== 0) {
@@ -1229,7 +1184,7 @@ export const InputAudioState = {
 
   fromJSON(object: any): InputAudioState {
     return {
-      mimeType: isSet(object.mimeType) ? String(object.mimeType) : '',
+      mimeType: isSet(object.mimeType) ? String(object.mimeType) : "",
       channels: isSet(object.channels) ? Number(object.channels) : 0,
       sampleRate: isSet(object.sampleRate) ? Number(object.sampleRate) : 0,
     };
@@ -1245,7 +1200,7 @@ export const InputAudioState = {
 
   fromPartial<I extends Exact<DeepPartial<InputAudioState>, I>>(object: I): InputAudioState {
     const message = createBaseInputAudioState();
-    message.mimeType = object.mimeType ?? '';
+    message.mimeType = object.mimeType ?? "";
     message.channels = object.channels ?? 0;
     message.sampleRate = object.sampleRate ?? 0;
     return message;
@@ -1254,11 +1209,11 @@ export const InputAudioState = {
 
 function createBaseUpdateIngressRequest(): UpdateIngressRequest {
   return {
-    ingressId: '',
-    name: '',
-    roomName: '',
-    participantIdentity: '',
-    participantName: '',
+    ingressId: "",
+    name: "",
+    roomName: "",
+    participantIdentity: "",
+    participantName: "",
     bypassTranscoding: undefined,
     audio: undefined,
     video: undefined,
@@ -1267,19 +1222,19 @@ function createBaseUpdateIngressRequest(): UpdateIngressRequest {
 
 export const UpdateIngressRequest = {
   encode(message: UpdateIngressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.ingressId !== undefined && message.ingressId !== '') {
+    if (message.ingressId !== undefined && message.ingressId !== "") {
       writer.uint32(10).string(message.ingressId);
     }
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(18).string(message.name);
     }
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(26).string(message.roomName);
     }
-    if (message.participantIdentity !== undefined && message.participantIdentity !== '') {
+    if (message.participantIdentity !== undefined && message.participantIdentity !== "") {
       writer.uint32(34).string(message.participantIdentity);
     }
-    if (message.participantName !== undefined && message.participantName !== '') {
+    if (message.participantName !== undefined && message.participantName !== "") {
       writer.uint32(42).string(message.participantName);
     }
     if (message.bypassTranscoding !== undefined) {
@@ -1335,16 +1290,12 @@ export const UpdateIngressRequest = {
 
   fromJSON(object: any): UpdateIngressRequest {
     return {
-      ingressId: isSet(object.ingressId) ? String(object.ingressId) : '',
-      name: isSet(object.name) ? String(object.name) : '',
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-      participantIdentity: isSet(object.participantIdentity)
-        ? String(object.participantIdentity)
-        : '',
-      participantName: isSet(object.participantName) ? String(object.participantName) : '',
-      bypassTranscoding: isSet(object.bypassTranscoding)
-        ? Boolean(object.bypassTranscoding)
-        : undefined,
+      ingressId: isSet(object.ingressId) ? String(object.ingressId) : "",
+      name: isSet(object.name) ? String(object.name) : "",
+      roomName: isSet(object.roomName) ? String(object.roomName) : "",
+      participantIdentity: isSet(object.participantIdentity) ? String(object.participantIdentity) : "",
+      participantName: isSet(object.participantName) ? String(object.participantName) : "",
+      bypassTranscoding: isSet(object.bypassTranscoding) ? Boolean(object.bypassTranscoding) : undefined,
       audio: isSet(object.audio) ? IngressAudioOptions.fromJSON(object.audio) : undefined,
       video: isSet(object.video) ? IngressVideoOptions.fromJSON(object.video) : undefined,
     };
@@ -1355,46 +1306,39 @@ export const UpdateIngressRequest = {
     message.ingressId !== undefined && (obj.ingressId = message.ingressId);
     message.name !== undefined && (obj.name = message.name);
     message.roomName !== undefined && (obj.roomName = message.roomName);
-    message.participantIdentity !== undefined &&
-      (obj.participantIdentity = message.participantIdentity);
+    message.participantIdentity !== undefined && (obj.participantIdentity = message.participantIdentity);
     message.participantName !== undefined && (obj.participantName = message.participantName);
     message.bypassTranscoding !== undefined && (obj.bypassTranscoding = message.bypassTranscoding);
-    message.audio !== undefined &&
-      (obj.audio = message.audio ? IngressAudioOptions.toJSON(message.audio) : undefined);
-    message.video !== undefined &&
-      (obj.video = message.video ? IngressVideoOptions.toJSON(message.video) : undefined);
+    message.audio !== undefined && (obj.audio = message.audio ? IngressAudioOptions.toJSON(message.audio) : undefined);
+    message.video !== undefined && (obj.video = message.video ? IngressVideoOptions.toJSON(message.video) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateIngressRequest>, I>>(
-    object: I,
-  ): UpdateIngressRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdateIngressRequest>, I>>(object: I): UpdateIngressRequest {
     const message = createBaseUpdateIngressRequest();
-    message.ingressId = object.ingressId ?? '';
-    message.name = object.name ?? '';
-    message.roomName = object.roomName ?? '';
-    message.participantIdentity = object.participantIdentity ?? '';
-    message.participantName = object.participantName ?? '';
+    message.ingressId = object.ingressId ?? "";
+    message.name = object.name ?? "";
+    message.roomName = object.roomName ?? "";
+    message.participantIdentity = object.participantIdentity ?? "";
+    message.participantName = object.participantName ?? "";
     message.bypassTranscoding = object.bypassTranscoding ?? undefined;
-    message.audio =
-      object.audio !== undefined && object.audio !== null
-        ? IngressAudioOptions.fromPartial(object.audio)
-        : undefined;
-    message.video =
-      object.video !== undefined && object.video !== null
-        ? IngressVideoOptions.fromPartial(object.video)
-        : undefined;
+    message.audio = (object.audio !== undefined && object.audio !== null)
+      ? IngressAudioOptions.fromPartial(object.audio)
+      : undefined;
+    message.video = (object.video !== undefined && object.video !== null)
+      ? IngressVideoOptions.fromPartial(object.video)
+      : undefined;
     return message;
   },
 };
 
 function createBaseListIngressRequest(): ListIngressRequest {
-  return { roomName: '' };
+  return { roomName: "" };
 }
 
 export const ListIngressRequest = {
   encode(message: ListIngressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.roomName !== undefined && message.roomName !== '') {
+    if (message.roomName !== undefined && message.roomName !== "") {
       writer.uint32(10).string(message.roomName);
     }
     return writer;
@@ -1419,9 +1363,7 @@ export const ListIngressRequest = {
   },
 
   fromJSON(object: any): ListIngressRequest {
-    return {
-      roomName: isSet(object.roomName) ? String(object.roomName) : '',
-    };
+    return { roomName: isSet(object.roomName) ? String(object.roomName) : "" };
   },
 
   toJSON(message: ListIngressRequest): unknown {
@@ -1432,7 +1374,7 @@ export const ListIngressRequest = {
 
   fromPartial<I extends Exact<DeepPartial<ListIngressRequest>, I>>(object: I): ListIngressRequest {
     const message = createBaseListIngressRequest();
-    message.roomName = object.roomName ?? '';
+    message.roomName = object.roomName ?? "";
     return message;
   },
 };
@@ -1470,26 +1412,20 @@ export const ListIngressResponse = {
   },
 
   fromJSON(object: any): ListIngressResponse {
-    return {
-      items: Array.isArray(object?.items)
-        ? object.items.map((e: any) => IngressInfo.fromJSON(e))
-        : [],
-    };
+    return { items: Array.isArray(object?.items) ? object.items.map((e: any) => IngressInfo.fromJSON(e)) : [] };
   },
 
   toJSON(message: ListIngressResponse): unknown {
     const obj: any = {};
     if (message.items) {
-      obj.items = message.items.map((e) => (e ? IngressInfo.toJSON(e) : undefined));
+      obj.items = message.items.map((e) => e ? IngressInfo.toJSON(e) : undefined);
     } else {
       obj.items = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ListIngressResponse>, I>>(
-    object: I,
-  ): ListIngressResponse {
+  fromPartial<I extends Exact<DeepPartial<ListIngressResponse>, I>>(object: I): ListIngressResponse {
     const message = createBaseListIngressResponse();
     message.items = object.items?.map((e) => IngressInfo.fromPartial(e)) || [];
     return message;
@@ -1497,12 +1433,12 @@ export const ListIngressResponse = {
 };
 
 function createBaseDeleteIngressRequest(): DeleteIngressRequest {
-  return { ingressId: '' };
+  return { ingressId: "" };
 }
 
 export const DeleteIngressRequest = {
   encode(message: DeleteIngressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.ingressId !== undefined && message.ingressId !== '') {
+    if (message.ingressId !== undefined && message.ingressId !== "") {
       writer.uint32(10).string(message.ingressId);
     }
     return writer;
@@ -1527,9 +1463,7 @@ export const DeleteIngressRequest = {
   },
 
   fromJSON(object: any): DeleteIngressRequest {
-    return {
-      ingressId: isSet(object.ingressId) ? String(object.ingressId) : '',
-    };
+    return { ingressId: isSet(object.ingressId) ? String(object.ingressId) : "" };
   },
 
   toJSON(message: DeleteIngressRequest): unknown {
@@ -1538,11 +1472,9 @@ export const DeleteIngressRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<DeleteIngressRequest>, I>>(
-    object: I,
-  ): DeleteIngressRequest {
+  fromPartial<I extends Exact<DeepPartial<DeleteIngressRequest>, I>>(object: I): DeleteIngressRequest {
     const message = createBaseDeleteIngressRequest();
-    message.ingressId = object.ingressId ?? '';
+    message.ingressId = object.ingressId ?? "";
     return message;
   },
 };
@@ -1560,33 +1492,35 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
 })();
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }

--- a/src/proto/livekit_models.ts
+++ b/src/proto/livekit_models.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
-import { Timestamp } from './google/protobuf/timestamp';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import { Timestamp } from "./google/protobuf/timestamp";
 
-export const protobufPackage = 'livekit';
+export const protobufPackage = "livekit";
 
 export enum AudioCodec {
   DEFAULT_AC = 0,
@@ -15,16 +15,16 @@ export enum AudioCodec {
 export function audioCodecFromJSON(object: any): AudioCodec {
   switch (object) {
     case 0:
-    case 'DEFAULT_AC':
+    case "DEFAULT_AC":
       return AudioCodec.DEFAULT_AC;
     case 1:
-    case 'OPUS':
+    case "OPUS":
       return AudioCodec.OPUS;
     case 2:
-    case 'AAC':
+    case "AAC":
       return AudioCodec.AAC;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return AudioCodec.UNRECOGNIZED;
   }
@@ -33,13 +33,14 @@ export function audioCodecFromJSON(object: any): AudioCodec {
 export function audioCodecToJSON(object: AudioCodec): string {
   switch (object) {
     case AudioCodec.DEFAULT_AC:
-      return 'DEFAULT_AC';
+      return "DEFAULT_AC";
     case AudioCodec.OPUS:
-      return 'OPUS';
+      return "OPUS";
     case AudioCodec.AAC:
-      return 'AAC';
+      return "AAC";
+    case AudioCodec.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -55,22 +56,22 @@ export enum VideoCodec {
 export function videoCodecFromJSON(object: any): VideoCodec {
   switch (object) {
     case 0:
-    case 'DEFAULT_VC':
+    case "DEFAULT_VC":
       return VideoCodec.DEFAULT_VC;
     case 1:
-    case 'H264_BASELINE':
+    case "H264_BASELINE":
       return VideoCodec.H264_BASELINE;
     case 2:
-    case 'H264_MAIN':
+    case "H264_MAIN":
       return VideoCodec.H264_MAIN;
     case 3:
-    case 'H264_HIGH':
+    case "H264_HIGH":
       return VideoCodec.H264_HIGH;
     case 4:
-    case 'VP8':
+    case "VP8":
       return VideoCodec.VP8;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return VideoCodec.UNRECOGNIZED;
   }
@@ -79,17 +80,18 @@ export function videoCodecFromJSON(object: any): VideoCodec {
 export function videoCodecToJSON(object: VideoCodec): string {
   switch (object) {
     case VideoCodec.DEFAULT_VC:
-      return 'DEFAULT_VC';
+      return "DEFAULT_VC";
     case VideoCodec.H264_BASELINE:
-      return 'H264_BASELINE';
+      return "H264_BASELINE";
     case VideoCodec.H264_MAIN:
-      return 'H264_MAIN';
+      return "H264_MAIN";
     case VideoCodec.H264_HIGH:
-      return 'H264_HIGH';
+      return "H264_HIGH";
     case VideoCodec.VP8:
-      return 'VP8';
+      return "VP8";
+    case VideoCodec.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -103,16 +105,16 @@ export enum TrackType {
 export function trackTypeFromJSON(object: any): TrackType {
   switch (object) {
     case 0:
-    case 'AUDIO':
+    case "AUDIO":
       return TrackType.AUDIO;
     case 1:
-    case 'VIDEO':
+    case "VIDEO":
       return TrackType.VIDEO;
     case 2:
-    case 'DATA':
+    case "DATA":
       return TrackType.DATA;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return TrackType.UNRECOGNIZED;
   }
@@ -121,13 +123,14 @@ export function trackTypeFromJSON(object: any): TrackType {
 export function trackTypeToJSON(object: TrackType): string {
   switch (object) {
     case TrackType.AUDIO:
-      return 'AUDIO';
+      return "AUDIO";
     case TrackType.VIDEO:
-      return 'VIDEO';
+      return "VIDEO";
     case TrackType.DATA:
-      return 'DATA';
+      return "DATA";
+    case TrackType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -143,22 +146,22 @@ export enum TrackSource {
 export function trackSourceFromJSON(object: any): TrackSource {
   switch (object) {
     case 0:
-    case 'UNKNOWN':
+    case "UNKNOWN":
       return TrackSource.UNKNOWN;
     case 1:
-    case 'CAMERA':
+    case "CAMERA":
       return TrackSource.CAMERA;
     case 2:
-    case 'MICROPHONE':
+    case "MICROPHONE":
       return TrackSource.MICROPHONE;
     case 3:
-    case 'SCREEN_SHARE':
+    case "SCREEN_SHARE":
       return TrackSource.SCREEN_SHARE;
     case 4:
-    case 'SCREEN_SHARE_AUDIO':
+    case "SCREEN_SHARE_AUDIO":
       return TrackSource.SCREEN_SHARE_AUDIO;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return TrackSource.UNRECOGNIZED;
   }
@@ -167,17 +170,18 @@ export function trackSourceFromJSON(object: any): TrackSource {
 export function trackSourceToJSON(object: TrackSource): string {
   switch (object) {
     case TrackSource.UNKNOWN:
-      return 'UNKNOWN';
+      return "UNKNOWN";
     case TrackSource.CAMERA:
-      return 'CAMERA';
+      return "CAMERA";
     case TrackSource.MICROPHONE:
-      return 'MICROPHONE';
+      return "MICROPHONE";
     case TrackSource.SCREEN_SHARE:
-      return 'SCREEN_SHARE';
+      return "SCREEN_SHARE";
     case TrackSource.SCREEN_SHARE_AUDIO:
-      return 'SCREEN_SHARE_AUDIO';
+      return "SCREEN_SHARE_AUDIO";
+    case TrackSource.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -192,19 +196,19 @@ export enum VideoQuality {
 export function videoQualityFromJSON(object: any): VideoQuality {
   switch (object) {
     case 0:
-    case 'LOW':
+    case "LOW":
       return VideoQuality.LOW;
     case 1:
-    case 'MEDIUM':
+    case "MEDIUM":
       return VideoQuality.MEDIUM;
     case 2:
-    case 'HIGH':
+    case "HIGH":
       return VideoQuality.HIGH;
     case 3:
-    case 'OFF':
+    case "OFF":
       return VideoQuality.OFF;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return VideoQuality.UNRECOGNIZED;
   }
@@ -213,15 +217,16 @@ export function videoQualityFromJSON(object: any): VideoQuality {
 export function videoQualityToJSON(object: VideoQuality): string {
   switch (object) {
     case VideoQuality.LOW:
-      return 'LOW';
+      return "LOW";
     case VideoQuality.MEDIUM:
-      return 'MEDIUM';
+      return "MEDIUM";
     case VideoQuality.HIGH:
-      return 'HIGH';
+      return "HIGH";
     case VideoQuality.OFF:
-      return 'OFF';
+      return "OFF";
+    case VideoQuality.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -235,16 +240,16 @@ export enum ConnectionQuality {
 export function connectionQualityFromJSON(object: any): ConnectionQuality {
   switch (object) {
     case 0:
-    case 'POOR':
+    case "POOR":
       return ConnectionQuality.POOR;
     case 1:
-    case 'GOOD':
+    case "GOOD":
       return ConnectionQuality.GOOD;
     case 2:
-    case 'EXCELLENT':
+    case "EXCELLENT":
       return ConnectionQuality.EXCELLENT;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return ConnectionQuality.UNRECOGNIZED;
   }
@@ -253,13 +258,14 @@ export function connectionQualityFromJSON(object: any): ConnectionQuality {
 export function connectionQualityToJSON(object: ConnectionQuality): string {
   switch (object) {
     case ConnectionQuality.POOR:
-      return 'POOR';
+      return "POOR";
     case ConnectionQuality.GOOD:
-      return 'GOOD';
+      return "GOOD";
     case ConnectionQuality.EXCELLENT:
-      return 'EXCELLENT';
+      return "EXCELLENT";
+    case ConnectionQuality.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -273,16 +279,16 @@ export enum ClientConfigSetting {
 export function clientConfigSettingFromJSON(object: any): ClientConfigSetting {
   switch (object) {
     case 0:
-    case 'UNSET':
+    case "UNSET":
       return ClientConfigSetting.UNSET;
     case 1:
-    case 'DISABLED':
+    case "DISABLED":
       return ClientConfigSetting.DISABLED;
     case 2:
-    case 'ENABLED':
+    case "ENABLED":
       return ClientConfigSetting.ENABLED;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return ClientConfigSetting.UNRECOGNIZED;
   }
@@ -291,13 +297,14 @@ export function clientConfigSettingFromJSON(object: any): ClientConfigSetting {
 export function clientConfigSettingToJSON(object: ClientConfigSetting): string {
   switch (object) {
     case ClientConfigSetting.UNSET:
-      return 'UNSET';
+      return "UNSET";
     case ClientConfigSetting.DISABLED:
-      return 'DISABLED';
+      return "DISABLED";
     case ClientConfigSetting.ENABLED:
-      return 'ENABLED';
+      return "ENABLED";
+    case ClientConfigSetting.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -316,31 +323,31 @@ export enum DisconnectReason {
 export function disconnectReasonFromJSON(object: any): DisconnectReason {
   switch (object) {
     case 0:
-    case 'UNKNOWN_REASON':
+    case "UNKNOWN_REASON":
       return DisconnectReason.UNKNOWN_REASON;
     case 1:
-    case 'CLIENT_INITIATED':
+    case "CLIENT_INITIATED":
       return DisconnectReason.CLIENT_INITIATED;
     case 2:
-    case 'DUPLICATE_IDENTITY':
+    case "DUPLICATE_IDENTITY":
       return DisconnectReason.DUPLICATE_IDENTITY;
     case 3:
-    case 'SERVER_SHUTDOWN':
+    case "SERVER_SHUTDOWN":
       return DisconnectReason.SERVER_SHUTDOWN;
     case 4:
-    case 'PARTICIPANT_REMOVED':
+    case "PARTICIPANT_REMOVED":
       return DisconnectReason.PARTICIPANT_REMOVED;
     case 5:
-    case 'ROOM_DELETED':
+    case "ROOM_DELETED":
       return DisconnectReason.ROOM_DELETED;
     case 6:
-    case 'STATE_MISMATCH':
+    case "STATE_MISMATCH":
       return DisconnectReason.STATE_MISMATCH;
     case 7:
-    case 'JOIN_FAILURE':
+    case "JOIN_FAILURE":
       return DisconnectReason.JOIN_FAILURE;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return DisconnectReason.UNRECOGNIZED;
   }
@@ -349,28 +356,29 @@ export function disconnectReasonFromJSON(object: any): DisconnectReason {
 export function disconnectReasonToJSON(object: DisconnectReason): string {
   switch (object) {
     case DisconnectReason.UNKNOWN_REASON:
-      return 'UNKNOWN_REASON';
+      return "UNKNOWN_REASON";
     case DisconnectReason.CLIENT_INITIATED:
-      return 'CLIENT_INITIATED';
+      return "CLIENT_INITIATED";
     case DisconnectReason.DUPLICATE_IDENTITY:
-      return 'DUPLICATE_IDENTITY';
+      return "DUPLICATE_IDENTITY";
     case DisconnectReason.SERVER_SHUTDOWN:
-      return 'SERVER_SHUTDOWN';
+      return "SERVER_SHUTDOWN";
     case DisconnectReason.PARTICIPANT_REMOVED:
-      return 'PARTICIPANT_REMOVED';
+      return "PARTICIPANT_REMOVED";
     case DisconnectReason.ROOM_DELETED:
-      return 'ROOM_DELETED';
+      return "ROOM_DELETED";
     case DisconnectReason.STATE_MISMATCH:
-      return 'STATE_MISMATCH';
+      return "STATE_MISMATCH";
     case DisconnectReason.JOIN_FAILURE:
-      return 'JOIN_FAILURE';
+      return "JOIN_FAILURE";
+    case DisconnectReason.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
 export enum ReconnectReason {
-  RR_UNKOWN = 0,
+  RR_UNKNOWN = 0,
   RR_SIGNAL_DISCONNECTED = 1,
   RR_PUBLISHER_FAILED = 2,
   RR_SUBSCRIBER_FAILED = 3,
@@ -381,22 +389,22 @@ export enum ReconnectReason {
 export function reconnectReasonFromJSON(object: any): ReconnectReason {
   switch (object) {
     case 0:
-    case 'RR_UNKOWN':
-      return ReconnectReason.RR_UNKOWN;
+    case "RR_UNKNOWN":
+      return ReconnectReason.RR_UNKNOWN;
     case 1:
-    case 'RR_SIGNAL_DISCONNECTED':
+    case "RR_SIGNAL_DISCONNECTED":
       return ReconnectReason.RR_SIGNAL_DISCONNECTED;
     case 2:
-    case 'RR_PUBLISHER_FAILED':
+    case "RR_PUBLISHER_FAILED":
       return ReconnectReason.RR_PUBLISHER_FAILED;
     case 3:
-    case 'RR_SUBSCRIBER_FAILED':
+    case "RR_SUBSCRIBER_FAILED":
       return ReconnectReason.RR_SUBSCRIBER_FAILED;
     case 4:
-    case 'RR_SWITCH_CANDIDATE':
+    case "RR_SWITCH_CANDIDATE":
       return ReconnectReason.RR_SWITCH_CANDIDATE;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return ReconnectReason.UNRECOGNIZED;
   }
@@ -404,23 +412,24 @@ export function reconnectReasonFromJSON(object: any): ReconnectReason {
 
 export function reconnectReasonToJSON(object: ReconnectReason): string {
   switch (object) {
-    case ReconnectReason.RR_UNKOWN:
-      return 'RR_UNKOWN';
+    case ReconnectReason.RR_UNKNOWN:
+      return "RR_UNKNOWN";
     case ReconnectReason.RR_SIGNAL_DISCONNECTED:
-      return 'RR_SIGNAL_DISCONNECTED';
+      return "RR_SIGNAL_DISCONNECTED";
     case ReconnectReason.RR_PUBLISHER_FAILED:
-      return 'RR_PUBLISHER_FAILED';
+      return "RR_PUBLISHER_FAILED";
     case ReconnectReason.RR_SUBSCRIBER_FAILED:
-      return 'RR_SUBSCRIBER_FAILED';
+      return "RR_SUBSCRIBER_FAILED";
     case ReconnectReason.RR_SWITCH_CANDIDATE:
-      return 'RR_SWITCH_CANDIDATE';
+      return "RR_SWITCH_CANDIDATE";
+    case ReconnectReason.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
 export enum SubscriptionError {
-  SE_UNKOWN = 0,
+  SE_UNKNOWN = 0,
   SE_CODEC_UNSUPPORTED = 1,
   SE_TRACK_NOTFOUND = 2,
   UNRECOGNIZED = -1,
@@ -429,16 +438,16 @@ export enum SubscriptionError {
 export function subscriptionErrorFromJSON(object: any): SubscriptionError {
   switch (object) {
     case 0:
-    case 'SE_UNKOWN':
-      return SubscriptionError.SE_UNKOWN;
+    case "SE_UNKNOWN":
+      return SubscriptionError.SE_UNKNOWN;
     case 1:
-    case 'SE_CODEC_UNSUPPORTED':
+    case "SE_CODEC_UNSUPPORTED":
       return SubscriptionError.SE_CODEC_UNSUPPORTED;
     case 2:
-    case 'SE_TRACK_NOTFOUND':
+    case "SE_TRACK_NOTFOUND":
       return SubscriptionError.SE_TRACK_NOTFOUND;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return SubscriptionError.UNRECOGNIZED;
   }
@@ -446,14 +455,15 @@ export function subscriptionErrorFromJSON(object: any): SubscriptionError {
 
 export function subscriptionErrorToJSON(object: SubscriptionError): string {
   switch (object) {
-    case SubscriptionError.SE_UNKOWN:
-      return 'SE_UNKOWN';
+    case SubscriptionError.SE_UNKNOWN:
+      return "SE_UNKNOWN";
     case SubscriptionError.SE_CODEC_UNSUPPORTED:
-      return 'SE_CODEC_UNSUPPORTED';
+      return "SE_CODEC_UNSUPPORTED";
     case SubscriptionError.SE_TRACK_NOTFOUND:
-      return 'SE_TRACK_NOTFOUND';
+      return "SE_TRACK_NOTFOUND";
+    case SubscriptionError.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -527,19 +537,19 @@ export enum ParticipantInfo_State {
 export function participantInfo_StateFromJSON(object: any): ParticipantInfo_State {
   switch (object) {
     case 0:
-    case 'JOINING':
+    case "JOINING":
       return ParticipantInfo_State.JOINING;
     case 1:
-    case 'JOINED':
+    case "JOINED":
       return ParticipantInfo_State.JOINED;
     case 2:
-    case 'ACTIVE':
+    case "ACTIVE":
       return ParticipantInfo_State.ACTIVE;
     case 3:
-    case 'DISCONNECTED':
+    case "DISCONNECTED":
       return ParticipantInfo_State.DISCONNECTED;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return ParticipantInfo_State.UNRECOGNIZED;
   }
@@ -548,19 +558,21 @@ export function participantInfo_StateFromJSON(object: any): ParticipantInfo_Stat
 export function participantInfo_StateToJSON(object: ParticipantInfo_State): string {
   switch (object) {
     case ParticipantInfo_State.JOINING:
-      return 'JOINING';
+      return "JOINING";
     case ParticipantInfo_State.JOINED:
-      return 'JOINED';
+      return "JOINED";
     case ParticipantInfo_State.ACTIVE:
-      return 'ACTIVE';
+      return "ACTIVE";
     case ParticipantInfo_State.DISCONNECTED:
-      return 'DISCONNECTED';
+      return "DISCONNECTED";
+    case ParticipantInfo_State.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
-export interface Encryption {}
+export interface Encryption {
+}
 
 export enum Encryption_Type {
   NONE = 0,
@@ -572,16 +584,16 @@ export enum Encryption_Type {
 export function encryption_TypeFromJSON(object: any): Encryption_Type {
   switch (object) {
     case 0:
-    case 'NONE':
+    case "NONE":
       return Encryption_Type.NONE;
     case 1:
-    case 'GCM':
+    case "GCM":
       return Encryption_Type.GCM;
     case 2:
-    case 'CUSTOM':
+    case "CUSTOM":
       return Encryption_Type.CUSTOM;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return Encryption_Type.UNRECOGNIZED;
   }
@@ -590,13 +602,14 @@ export function encryption_TypeFromJSON(object: any): Encryption_Type {
 export function encryption_TypeToJSON(object: Encryption_Type): string {
   switch (object) {
     case Encryption_Type.NONE:
-      return 'NONE';
+      return "NONE";
     case Encryption_Type.GCM:
-      return 'GCM';
+      return "GCM";
     case Encryption_Type.CUSTOM:
-      return 'CUSTOM';
+      return "CUSTOM";
+    case Encryption_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -663,13 +676,13 @@ export enum DataPacket_Kind {
 export function dataPacket_KindFromJSON(object: any): DataPacket_Kind {
   switch (object) {
     case 0:
-    case 'RELIABLE':
+    case "RELIABLE":
       return DataPacket_Kind.RELIABLE;
     case 1:
-    case 'LOSSY':
+    case "LOSSY":
       return DataPacket_Kind.LOSSY;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return DataPacket_Kind.UNRECOGNIZED;
   }
@@ -678,11 +691,12 @@ export function dataPacket_KindFromJSON(object: any): DataPacket_Kind {
 export function dataPacket_KindToJSON(object: DataPacket_Kind): string {
   switch (object) {
     case DataPacket_Kind.RELIABLE:
-      return 'RELIABLE';
+      return "RELIABLE";
     case DataPacket_Kind.LOSSY:
-      return 'LOSSY';
+      return "LOSSY";
+    case DataPacket_Kind.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -735,13 +749,13 @@ export enum ServerInfo_Edition {
 export function serverInfo_EditionFromJSON(object: any): ServerInfo_Edition {
   switch (object) {
     case 0:
-    case 'Standard':
+    case "Standard":
       return ServerInfo_Edition.Standard;
     case 1:
-    case 'Cloud':
+    case "Cloud":
       return ServerInfo_Edition.Cloud;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return ServerInfo_Edition.UNRECOGNIZED;
   }
@@ -750,11 +764,12 @@ export function serverInfo_EditionFromJSON(object: any): ServerInfo_Edition {
 export function serverInfo_EditionToJSON(object: ServerInfo_Edition): string {
   switch (object) {
     case ServerInfo_Edition.Standard:
-      return 'Standard';
+      return "Standard";
     case ServerInfo_Edition.Cloud:
-      return 'Cloud';
+      return "Cloud";
+    case ServerInfo_Edition.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -789,34 +804,34 @@ export enum ClientInfo_SDK {
 export function clientInfo_SDKFromJSON(object: any): ClientInfo_SDK {
   switch (object) {
     case 0:
-    case 'UNKNOWN':
+    case "UNKNOWN":
       return ClientInfo_SDK.UNKNOWN;
     case 1:
-    case 'JS':
+    case "JS":
       return ClientInfo_SDK.JS;
     case 2:
-    case 'SWIFT':
+    case "SWIFT":
       return ClientInfo_SDK.SWIFT;
     case 3:
-    case 'ANDROID':
+    case "ANDROID":
       return ClientInfo_SDK.ANDROID;
     case 4:
-    case 'FLUTTER':
+    case "FLUTTER":
       return ClientInfo_SDK.FLUTTER;
     case 5:
-    case 'GO':
+    case "GO":
       return ClientInfo_SDK.GO;
     case 6:
-    case 'UNITY':
+    case "UNITY":
       return ClientInfo_SDK.UNITY;
     case 7:
-    case 'REACT_NATIVE':
+    case "REACT_NATIVE":
       return ClientInfo_SDK.REACT_NATIVE;
     case 8:
-    case 'RUST':
+    case "RUST":
       return ClientInfo_SDK.RUST;
     case -1:
-    case 'UNRECOGNIZED':
+    case "UNRECOGNIZED":
     default:
       return ClientInfo_SDK.UNRECOGNIZED;
   }
@@ -825,25 +840,26 @@ export function clientInfo_SDKFromJSON(object: any): ClientInfo_SDK {
 export function clientInfo_SDKToJSON(object: ClientInfo_SDK): string {
   switch (object) {
     case ClientInfo_SDK.UNKNOWN:
-      return 'UNKNOWN';
+      return "UNKNOWN";
     case ClientInfo_SDK.JS:
-      return 'JS';
+      return "JS";
     case ClientInfo_SDK.SWIFT:
-      return 'SWIFT';
+      return "SWIFT";
     case ClientInfo_SDK.ANDROID:
-      return 'ANDROID';
+      return "ANDROID";
     case ClientInfo_SDK.FLUTTER:
-      return 'FLUTTER';
+      return "FLUTTER";
     case ClientInfo_SDK.GO:
-      return 'GO';
+      return "GO";
     case ClientInfo_SDK.UNITY:
-      return 'UNITY';
+      return "UNITY";
     case ClientInfo_SDK.REACT_NATIVE:
-      return 'REACT_NATIVE';
+      return "REACT_NATIVE";
     case ClientInfo_SDK.RUST:
-      return 'RUST';
+      return "RUST";
+    case ClientInfo_SDK.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return "UNRECOGNIZED";
   }
 }
 
@@ -926,14 +942,14 @@ export interface TimedVersion {
 
 function createBaseRoom(): Room {
   return {
-    sid: '',
-    name: '',
+    sid: "",
+    name: "",
     emptyTimeout: 0,
     maxParticipants: 0,
     creationTime: 0,
-    turnPassword: '',
+    turnPassword: "",
     enabledCodecs: [],
-    metadata: '',
+    metadata: "",
     numParticipants: 0,
     numPublishers: 0,
     activeRecording: false,
@@ -942,10 +958,10 @@ function createBaseRoom(): Room {
 
 export const Room = {
   encode(message: Room, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.sid !== '') {
+    if (message.sid !== "") {
       writer.uint32(10).string(message.sid);
     }
-    if (message.name !== '') {
+    if (message.name !== "") {
       writer.uint32(18).string(message.name);
     }
     if (message.emptyTimeout !== 0) {
@@ -957,13 +973,13 @@ export const Room = {
     if (message.creationTime !== 0) {
       writer.uint32(40).int64(message.creationTime);
     }
-    if (message.turnPassword !== '') {
+    if (message.turnPassword !== "") {
       writer.uint32(50).string(message.turnPassword);
     }
     for (const v of message.enabledCodecs) {
       Codec.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.metadata !== '') {
+    if (message.metadata !== "") {
       writer.uint32(66).string(message.metadata);
     }
     if (message.numParticipants !== 0) {
@@ -1028,16 +1044,16 @@ export const Room = {
 
   fromJSON(object: any): Room {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : '',
-      name: isSet(object.name) ? String(object.name) : '',
+      sid: isSet(object.sid) ? String(object.sid) : "",
+      name: isSet(object.name) ? String(object.name) : "",
       emptyTimeout: isSet(object.emptyTimeout) ? Number(object.emptyTimeout) : 0,
       maxParticipants: isSet(object.maxParticipants) ? Number(object.maxParticipants) : 0,
       creationTime: isSet(object.creationTime) ? Number(object.creationTime) : 0,
-      turnPassword: isSet(object.turnPassword) ? String(object.turnPassword) : '',
+      turnPassword: isSet(object.turnPassword) ? String(object.turnPassword) : "",
       enabledCodecs: Array.isArray(object?.enabledCodecs)
         ? object.enabledCodecs.map((e: any) => Codec.fromJSON(e))
         : [],
-      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : "",
       numParticipants: isSet(object.numParticipants) ? Number(object.numParticipants) : 0,
       numPublishers: isSet(object.numPublishers) ? Number(object.numPublishers) : 0,
       activeRecording: isSet(object.activeRecording) ? Boolean(object.activeRecording) : false,
@@ -1049,18 +1065,16 @@ export const Room = {
     message.sid !== undefined && (obj.sid = message.sid);
     message.name !== undefined && (obj.name = message.name);
     message.emptyTimeout !== undefined && (obj.emptyTimeout = Math.round(message.emptyTimeout));
-    message.maxParticipants !== undefined &&
-      (obj.maxParticipants = Math.round(message.maxParticipants));
+    message.maxParticipants !== undefined && (obj.maxParticipants = Math.round(message.maxParticipants));
     message.creationTime !== undefined && (obj.creationTime = Math.round(message.creationTime));
     message.turnPassword !== undefined && (obj.turnPassword = message.turnPassword);
     if (message.enabledCodecs) {
-      obj.enabledCodecs = message.enabledCodecs.map((e) => (e ? Codec.toJSON(e) : undefined));
+      obj.enabledCodecs = message.enabledCodecs.map((e) => e ? Codec.toJSON(e) : undefined);
     } else {
       obj.enabledCodecs = [];
     }
     message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.numParticipants !== undefined &&
-      (obj.numParticipants = Math.round(message.numParticipants));
+    message.numParticipants !== undefined && (obj.numParticipants = Math.round(message.numParticipants));
     message.numPublishers !== undefined && (obj.numPublishers = Math.round(message.numPublishers));
     message.activeRecording !== undefined && (obj.activeRecording = message.activeRecording);
     return obj;
@@ -1068,14 +1082,14 @@ export const Room = {
 
   fromPartial<I extends Exact<DeepPartial<Room>, I>>(object: I): Room {
     const message = createBaseRoom();
-    message.sid = object.sid ?? '';
-    message.name = object.name ?? '';
+    message.sid = object.sid ?? "";
+    message.name = object.name ?? "";
     message.emptyTimeout = object.emptyTimeout ?? 0;
     message.maxParticipants = object.maxParticipants ?? 0;
     message.creationTime = object.creationTime ?? 0;
-    message.turnPassword = object.turnPassword ?? '';
+    message.turnPassword = object.turnPassword ?? "";
     message.enabledCodecs = object.enabledCodecs?.map((e) => Codec.fromPartial(e)) || [];
-    message.metadata = object.metadata ?? '';
+    message.metadata = object.metadata ?? "";
     message.numParticipants = object.numParticipants ?? 0;
     message.numPublishers = object.numPublishers ?? 0;
     message.activeRecording = object.activeRecording ?? false;
@@ -1084,15 +1098,15 @@ export const Room = {
 };
 
 function createBaseCodec(): Codec {
-  return { mime: '', fmtpLine: '' };
+  return { mime: "", fmtpLine: "" };
 }
 
 export const Codec = {
   encode(message: Codec, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.mime !== '') {
+    if (message.mime !== "") {
       writer.uint32(10).string(message.mime);
     }
-    if (message.fmtpLine !== '') {
+    if (message.fmtpLine !== "") {
       writer.uint32(18).string(message.fmtpLine);
     }
     return writer;
@@ -1121,8 +1135,8 @@ export const Codec = {
 
   fromJSON(object: any): Codec {
     return {
-      mime: isSet(object.mime) ? String(object.mime) : '',
-      fmtpLine: isSet(object.fmtpLine) ? String(object.fmtpLine) : '',
+      mime: isSet(object.mime) ? String(object.mime) : "",
+      fmtpLine: isSet(object.fmtpLine) ? String(object.fmtpLine) : "",
     };
   },
 
@@ -1135,8 +1149,8 @@ export const Codec = {
 
   fromPartial<I extends Exact<DeepPartial<Codec>, I>>(object: I): Codec {
     const message = createBaseCodec();
-    message.mime = object.mime ?? '';
-    message.fmtpLine = object.fmtpLine ?? '';
+    message.mime = object.mime ?? "";
+    message.fmtpLine = object.fmtpLine ?? "";
     return message;
   },
 };
@@ -1234,9 +1248,7 @@ export const ParticipantPermission = {
         : [],
       hidden: isSet(object.hidden) ? Boolean(object.hidden) : false,
       recorder: isSet(object.recorder) ? Boolean(object.recorder) : false,
-      canUpdateMetadata: isSet(object.canUpdateMetadata)
-        ? Boolean(object.canUpdateMetadata)
-        : false,
+      canUpdateMetadata: isSet(object.canUpdateMetadata) ? Boolean(object.canUpdateMetadata) : false,
     };
   },
 
@@ -1256,9 +1268,7 @@ export const ParticipantPermission = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ParticipantPermission>, I>>(
-    object: I,
-  ): ParticipantPermission {
+  fromPartial<I extends Exact<DeepPartial<ParticipantPermission>, I>>(object: I): ParticipantPermission {
     const message = createBaseParticipantPermission();
     message.canSubscribe = object.canSubscribe ?? false;
     message.canPublish = object.canPublish ?? false;
@@ -1273,26 +1283,26 @@ export const ParticipantPermission = {
 
 function createBaseParticipantInfo(): ParticipantInfo {
   return {
-    sid: '',
-    identity: '',
+    sid: "",
+    identity: "",
     state: 0,
     tracks: [],
-    metadata: '',
+    metadata: "",
     joinedAt: 0,
-    name: '',
+    name: "",
     version: 0,
     permission: undefined,
-    region: '',
+    region: "",
     isPublisher: false,
   };
 }
 
 export const ParticipantInfo = {
   encode(message: ParticipantInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.sid !== '') {
+    if (message.sid !== "") {
       writer.uint32(10).string(message.sid);
     }
-    if (message.identity !== '') {
+    if (message.identity !== "") {
       writer.uint32(18).string(message.identity);
     }
     if (message.state !== 0) {
@@ -1301,13 +1311,13 @@ export const ParticipantInfo = {
     for (const v of message.tracks) {
       TrackInfo.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.metadata !== '') {
+    if (message.metadata !== "") {
       writer.uint32(42).string(message.metadata);
     }
     if (message.joinedAt !== 0) {
       writer.uint32(48).int64(message.joinedAt);
     }
-    if (message.name !== '') {
+    if (message.name !== "") {
       writer.uint32(74).string(message.name);
     }
     if (message.version !== 0) {
@@ -1316,7 +1326,7 @@ export const ParticipantInfo = {
     if (message.permission !== undefined) {
       ParticipantPermission.encode(message.permission, writer.uint32(90).fork()).ldelim();
     }
-    if (message.region !== '') {
+    if (message.region !== "") {
       writer.uint32(98).string(message.region);
     }
     if (message.isPublisher === true) {
@@ -1375,20 +1385,16 @@ export const ParticipantInfo = {
 
   fromJSON(object: any): ParticipantInfo {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : '',
-      identity: isSet(object.identity) ? String(object.identity) : '',
+      sid: isSet(object.sid) ? String(object.sid) : "",
+      identity: isSet(object.identity) ? String(object.identity) : "",
       state: isSet(object.state) ? participantInfo_StateFromJSON(object.state) : 0,
-      tracks: Array.isArray(object?.tracks)
-        ? object.tracks.map((e: any) => TrackInfo.fromJSON(e))
-        : [],
-      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      tracks: Array.isArray(object?.tracks) ? object.tracks.map((e: any) => TrackInfo.fromJSON(e)) : [],
+      metadata: isSet(object.metadata) ? String(object.metadata) : "",
       joinedAt: isSet(object.joinedAt) ? Number(object.joinedAt) : 0,
-      name: isSet(object.name) ? String(object.name) : '',
+      name: isSet(object.name) ? String(object.name) : "",
       version: isSet(object.version) ? Number(object.version) : 0,
-      permission: isSet(object.permission)
-        ? ParticipantPermission.fromJSON(object.permission)
-        : undefined,
-      region: isSet(object.region) ? String(object.region) : '',
+      permission: isSet(object.permission) ? ParticipantPermission.fromJSON(object.permission) : undefined,
+      region: isSet(object.region) ? String(object.region) : "",
       isPublisher: isSet(object.isPublisher) ? Boolean(object.isPublisher) : false,
     };
   },
@@ -1399,7 +1405,7 @@ export const ParticipantInfo = {
     message.identity !== undefined && (obj.identity = message.identity);
     message.state !== undefined && (obj.state = participantInfo_StateToJSON(message.state));
     if (message.tracks) {
-      obj.tracks = message.tracks.map((e) => (e ? TrackInfo.toJSON(e) : undefined));
+      obj.tracks = message.tracks.map((e) => e ? TrackInfo.toJSON(e) : undefined);
     } else {
       obj.tracks = [];
     }
@@ -1408,9 +1414,7 @@ export const ParticipantInfo = {
     message.name !== undefined && (obj.name = message.name);
     message.version !== undefined && (obj.version = Math.round(message.version));
     message.permission !== undefined &&
-      (obj.permission = message.permission
-        ? ParticipantPermission.toJSON(message.permission)
-        : undefined);
+      (obj.permission = message.permission ? ParticipantPermission.toJSON(message.permission) : undefined);
     message.region !== undefined && (obj.region = message.region);
     message.isPublisher !== undefined && (obj.isPublisher = message.isPublisher);
     return obj;
@@ -1418,19 +1422,18 @@ export const ParticipantInfo = {
 
   fromPartial<I extends Exact<DeepPartial<ParticipantInfo>, I>>(object: I): ParticipantInfo {
     const message = createBaseParticipantInfo();
-    message.sid = object.sid ?? '';
-    message.identity = object.identity ?? '';
+    message.sid = object.sid ?? "";
+    message.identity = object.identity ?? "";
     message.state = object.state ?? 0;
     message.tracks = object.tracks?.map((e) => TrackInfo.fromPartial(e)) || [];
-    message.metadata = object.metadata ?? '';
+    message.metadata = object.metadata ?? "";
     message.joinedAt = object.joinedAt ?? 0;
-    message.name = object.name ?? '';
+    message.name = object.name ?? "";
     message.version = object.version ?? 0;
-    message.permission =
-      object.permission !== undefined && object.permission !== null
-        ? ParticipantPermission.fromPartial(object.permission)
-        : undefined;
-    message.region = object.region ?? '';
+    message.permission = (object.permission !== undefined && object.permission !== null)
+      ? ParticipantPermission.fromPartial(object.permission)
+      : undefined;
+    message.region = object.region ?? "";
     message.isPublisher = object.isPublisher ?? false;
     return message;
   },
@@ -1476,18 +1479,18 @@ export const Encryption = {
 };
 
 function createBaseSimulcastCodecInfo(): SimulcastCodecInfo {
-  return { mimeType: '', mid: '', cid: '', layers: [] };
+  return { mimeType: "", mid: "", cid: "", layers: [] };
 }
 
 export const SimulcastCodecInfo = {
   encode(message: SimulcastCodecInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.mimeType !== '') {
+    if (message.mimeType !== "") {
       writer.uint32(10).string(message.mimeType);
     }
-    if (message.mid !== '') {
+    if (message.mid !== "") {
       writer.uint32(18).string(message.mid);
     }
-    if (message.cid !== '') {
+    if (message.cid !== "") {
       writer.uint32(26).string(message.cid);
     }
     for (const v of message.layers) {
@@ -1525,12 +1528,10 @@ export const SimulcastCodecInfo = {
 
   fromJSON(object: any): SimulcastCodecInfo {
     return {
-      mimeType: isSet(object.mimeType) ? String(object.mimeType) : '',
-      mid: isSet(object.mid) ? String(object.mid) : '',
-      cid: isSet(object.cid) ? String(object.cid) : '',
-      layers: Array.isArray(object?.layers)
-        ? object.layers.map((e: any) => VideoLayer.fromJSON(e))
-        : [],
+      mimeType: isSet(object.mimeType) ? String(object.mimeType) : "",
+      mid: isSet(object.mid) ? String(object.mid) : "",
+      cid: isSet(object.cid) ? String(object.cid) : "",
+      layers: Array.isArray(object?.layers) ? object.layers.map((e: any) => VideoLayer.fromJSON(e)) : [],
     };
   },
 
@@ -1540,7 +1541,7 @@ export const SimulcastCodecInfo = {
     message.mid !== undefined && (obj.mid = message.mid);
     message.cid !== undefined && (obj.cid = message.cid);
     if (message.layers) {
-      obj.layers = message.layers.map((e) => (e ? VideoLayer.toJSON(e) : undefined));
+      obj.layers = message.layers.map((e) => e ? VideoLayer.toJSON(e) : undefined);
     } else {
       obj.layers = [];
     }
@@ -1549,9 +1550,9 @@ export const SimulcastCodecInfo = {
 
   fromPartial<I extends Exact<DeepPartial<SimulcastCodecInfo>, I>>(object: I): SimulcastCodecInfo {
     const message = createBaseSimulcastCodecInfo();
-    message.mimeType = object.mimeType ?? '';
-    message.mid = object.mid ?? '';
-    message.cid = object.cid ?? '';
+    message.mimeType = object.mimeType ?? "";
+    message.mid = object.mid ?? "";
+    message.cid = object.cid ?? "";
     message.layers = object.layers?.map((e) => VideoLayer.fromPartial(e)) || [];
     return message;
   },
@@ -1559,9 +1560,9 @@ export const SimulcastCodecInfo = {
 
 function createBaseTrackInfo(): TrackInfo {
   return {
-    sid: '',
+    sid: "",
     type: 0,
-    name: '',
+    name: "",
     muted: false,
     width: 0,
     height: 0,
@@ -1569,8 +1570,8 @@ function createBaseTrackInfo(): TrackInfo {
     disableDtx: false,
     source: 0,
     layers: [],
-    mimeType: '',
-    mid: '',
+    mimeType: "",
+    mid: "",
     codecs: [],
     stereo: false,
     disableRed: false,
@@ -1580,13 +1581,13 @@ function createBaseTrackInfo(): TrackInfo {
 
 export const TrackInfo = {
   encode(message: TrackInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.sid !== '') {
+    if (message.sid !== "") {
       writer.uint32(10).string(message.sid);
     }
     if (message.type !== 0) {
       writer.uint32(16).int32(message.type);
     }
-    if (message.name !== '') {
+    if (message.name !== "") {
       writer.uint32(26).string(message.name);
     }
     if (message.muted === true) {
@@ -1610,10 +1611,10 @@ export const TrackInfo = {
     for (const v of message.layers) {
       VideoLayer.encode(v!, writer.uint32(82).fork()).ldelim();
     }
-    if (message.mimeType !== '') {
+    if (message.mimeType !== "") {
       writer.uint32(90).string(message.mimeType);
     }
-    if (message.mid !== '') {
+    if (message.mid !== "") {
       writer.uint32(98).string(message.mid);
     }
     for (const v of message.codecs) {
@@ -1696,23 +1697,19 @@ export const TrackInfo = {
 
   fromJSON(object: any): TrackInfo {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : '',
+      sid: isSet(object.sid) ? String(object.sid) : "",
       type: isSet(object.type) ? trackTypeFromJSON(object.type) : 0,
-      name: isSet(object.name) ? String(object.name) : '',
+      name: isSet(object.name) ? String(object.name) : "",
       muted: isSet(object.muted) ? Boolean(object.muted) : false,
       width: isSet(object.width) ? Number(object.width) : 0,
       height: isSet(object.height) ? Number(object.height) : 0,
       simulcast: isSet(object.simulcast) ? Boolean(object.simulcast) : false,
       disableDtx: isSet(object.disableDtx) ? Boolean(object.disableDtx) : false,
       source: isSet(object.source) ? trackSourceFromJSON(object.source) : 0,
-      layers: Array.isArray(object?.layers)
-        ? object.layers.map((e: any) => VideoLayer.fromJSON(e))
-        : [],
-      mimeType: isSet(object.mimeType) ? String(object.mimeType) : '',
-      mid: isSet(object.mid) ? String(object.mid) : '',
-      codecs: Array.isArray(object?.codecs)
-        ? object.codecs.map((e: any) => SimulcastCodecInfo.fromJSON(e))
-        : [],
+      layers: Array.isArray(object?.layers) ? object.layers.map((e: any) => VideoLayer.fromJSON(e)) : [],
+      mimeType: isSet(object.mimeType) ? String(object.mimeType) : "",
+      mid: isSet(object.mid) ? String(object.mid) : "",
+      codecs: Array.isArray(object?.codecs) ? object.codecs.map((e: any) => SimulcastCodecInfo.fromJSON(e)) : [],
       stereo: isSet(object.stereo) ? Boolean(object.stereo) : false,
       disableRed: isSet(object.disableRed) ? Boolean(object.disableRed) : false,
       encryption: isSet(object.encryption) ? encryption_TypeFromJSON(object.encryption) : 0,
@@ -1731,29 +1728,28 @@ export const TrackInfo = {
     message.disableDtx !== undefined && (obj.disableDtx = message.disableDtx);
     message.source !== undefined && (obj.source = trackSourceToJSON(message.source));
     if (message.layers) {
-      obj.layers = message.layers.map((e) => (e ? VideoLayer.toJSON(e) : undefined));
+      obj.layers = message.layers.map((e) => e ? VideoLayer.toJSON(e) : undefined);
     } else {
       obj.layers = [];
     }
     message.mimeType !== undefined && (obj.mimeType = message.mimeType);
     message.mid !== undefined && (obj.mid = message.mid);
     if (message.codecs) {
-      obj.codecs = message.codecs.map((e) => (e ? SimulcastCodecInfo.toJSON(e) : undefined));
+      obj.codecs = message.codecs.map((e) => e ? SimulcastCodecInfo.toJSON(e) : undefined);
     } else {
       obj.codecs = [];
     }
     message.stereo !== undefined && (obj.stereo = message.stereo);
     message.disableRed !== undefined && (obj.disableRed = message.disableRed);
-    message.encryption !== undefined &&
-      (obj.encryption = encryption_TypeToJSON(message.encryption));
+    message.encryption !== undefined && (obj.encryption = encryption_TypeToJSON(message.encryption));
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<TrackInfo>, I>>(object: I): TrackInfo {
     const message = createBaseTrackInfo();
-    message.sid = object.sid ?? '';
+    message.sid = object.sid ?? "";
     message.type = object.type ?? 0;
-    message.name = object.name ?? '';
+    message.name = object.name ?? "";
     message.muted = object.muted ?? false;
     message.width = object.width ?? 0;
     message.height = object.height ?? 0;
@@ -1761,8 +1757,8 @@ export const TrackInfo = {
     message.disableDtx = object.disableDtx ?? false;
     message.source = object.source ?? 0;
     message.layers = object.layers?.map((e) => VideoLayer.fromPartial(e)) || [];
-    message.mimeType = object.mimeType ?? '';
-    message.mid = object.mid ?? '';
+    message.mimeType = object.mimeType ?? "";
+    message.mid = object.mid ?? "";
     message.codecs = object.codecs?.map((e) => SimulcastCodecInfo.fromPartial(e)) || [];
     message.stereo = object.stereo ?? false;
     message.disableRed = object.disableRed ?? false;
@@ -1909,8 +1905,7 @@ export const DataPacket = {
   toJSON(message: DataPacket): unknown {
     const obj: any = {};
     message.kind !== undefined && (obj.kind = dataPacket_KindToJSON(message.kind));
-    message.user !== undefined &&
-      (obj.user = message.user ? UserPacket.toJSON(message.user) : undefined);
+    message.user !== undefined && (obj.user = message.user ? UserPacket.toJSON(message.user) : undefined);
     message.speaker !== undefined &&
       (obj.speaker = message.speaker ? ActiveSpeakerUpdate.toJSON(message.speaker) : undefined);
     return obj;
@@ -1919,14 +1914,12 @@ export const DataPacket = {
   fromPartial<I extends Exact<DeepPartial<DataPacket>, I>>(object: I): DataPacket {
     const message = createBaseDataPacket();
     message.kind = object.kind ?? 0;
-    message.user =
-      object.user !== undefined && object.user !== null
-        ? UserPacket.fromPartial(object.user)
-        : undefined;
-    message.speaker =
-      object.speaker !== undefined && object.speaker !== null
-        ? ActiveSpeakerUpdate.fromPartial(object.speaker)
-        : undefined;
+    message.user = (object.user !== undefined && object.user !== null)
+      ? UserPacket.fromPartial(object.user)
+      : undefined;
+    message.speaker = (object.speaker !== undefined && object.speaker !== null)
+      ? ActiveSpeakerUpdate.fromPartial(object.speaker)
+      : undefined;
     return message;
   },
 };
@@ -1963,25 +1956,21 @@ export const ActiveSpeakerUpdate = {
 
   fromJSON(object: any): ActiveSpeakerUpdate {
     return {
-      speakers: Array.isArray(object?.speakers)
-        ? object.speakers.map((e: any) => SpeakerInfo.fromJSON(e))
-        : [],
+      speakers: Array.isArray(object?.speakers) ? object.speakers.map((e: any) => SpeakerInfo.fromJSON(e)) : [],
     };
   },
 
   toJSON(message: ActiveSpeakerUpdate): unknown {
     const obj: any = {};
     if (message.speakers) {
-      obj.speakers = message.speakers.map((e) => (e ? SpeakerInfo.toJSON(e) : undefined));
+      obj.speakers = message.speakers.map((e) => e ? SpeakerInfo.toJSON(e) : undefined);
     } else {
       obj.speakers = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ActiveSpeakerUpdate>, I>>(
-    object: I,
-  ): ActiveSpeakerUpdate {
+  fromPartial<I extends Exact<DeepPartial<ActiveSpeakerUpdate>, I>>(object: I): ActiveSpeakerUpdate {
     const message = createBaseActiveSpeakerUpdate();
     message.speakers = object.speakers?.map((e) => SpeakerInfo.fromPartial(e)) || [];
     return message;
@@ -1989,12 +1978,12 @@ export const ActiveSpeakerUpdate = {
 };
 
 function createBaseSpeakerInfo(): SpeakerInfo {
-  return { sid: '', level: 0, active: false };
+  return { sid: "", level: 0, active: false };
 }
 
 export const SpeakerInfo = {
   encode(message: SpeakerInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.sid !== '') {
+    if (message.sid !== "") {
       writer.uint32(10).string(message.sid);
     }
     if (message.level !== 0) {
@@ -2032,7 +2021,7 @@ export const SpeakerInfo = {
 
   fromJSON(object: any): SpeakerInfo {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : '',
+      sid: isSet(object.sid) ? String(object.sid) : "",
       level: isSet(object.level) ? Number(object.level) : 0,
       active: isSet(object.active) ? Boolean(object.active) : false,
     };
@@ -2048,7 +2037,7 @@ export const SpeakerInfo = {
 
   fromPartial<I extends Exact<DeepPartial<SpeakerInfo>, I>>(object: I): SpeakerInfo {
     const message = createBaseSpeakerInfo();
-    message.sid = object.sid ?? '';
+    message.sid = object.sid ?? "";
     message.level = object.level ?? 0;
     message.active = object.active ?? false;
     return message;
@@ -2056,12 +2045,12 @@ export const SpeakerInfo = {
 };
 
 function createBaseUserPacket(): UserPacket {
-  return { participantSid: '', payload: new Uint8Array(), destinationSids: [], topic: undefined };
+  return { participantSid: "", payload: new Uint8Array(), destinationSids: [], topic: undefined };
 }
 
 export const UserPacket = {
   encode(message: UserPacket, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.participantSid !== '') {
+    if (message.participantSid !== "") {
       writer.uint32(10).string(message.participantSid);
     }
     if (message.payload.length !== 0) {
@@ -2105,11 +2094,9 @@ export const UserPacket = {
 
   fromJSON(object: any): UserPacket {
     return {
-      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : "",
       payload: isSet(object.payload) ? bytesFromBase64(object.payload) : new Uint8Array(),
-      destinationSids: Array.isArray(object?.destinationSids)
-        ? object.destinationSids.map((e: any) => String(e))
-        : [],
+      destinationSids: Array.isArray(object?.destinationSids) ? object.destinationSids.map((e: any) => String(e)) : [],
       topic: isSet(object.topic) ? String(object.topic) : undefined,
     };
   },
@@ -2118,9 +2105,7 @@ export const UserPacket = {
     const obj: any = {};
     message.participantSid !== undefined && (obj.participantSid = message.participantSid);
     message.payload !== undefined &&
-      (obj.payload = base64FromBytes(
-        message.payload !== undefined ? message.payload : new Uint8Array(),
-      ));
+      (obj.payload = base64FromBytes(message.payload !== undefined ? message.payload : new Uint8Array()));
     if (message.destinationSids) {
       obj.destinationSids = message.destinationSids.map((e) => e);
     } else {
@@ -2132,7 +2117,7 @@ export const UserPacket = {
 
   fromPartial<I extends Exact<DeepPartial<UserPacket>, I>>(object: I): UserPacket {
     const message = createBaseUserPacket();
-    message.participantSid = object.participantSid ?? '';
+    message.participantSid = object.participantSid ?? "";
     message.payload = object.payload ?? new Uint8Array();
     message.destinationSids = object.destinationSids?.map((e) => e) || [];
     message.topic = object.topic ?? undefined;
@@ -2141,12 +2126,12 @@ export const UserPacket = {
 };
 
 function createBaseParticipantTracks(): ParticipantTracks {
-  return { participantSid: '', trackSids: [] };
+  return { participantSid: "", trackSids: [] };
 }
 
 export const ParticipantTracks = {
   encode(message: ParticipantTracks, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.participantSid !== '') {
+    if (message.participantSid !== "") {
       writer.uint32(10).string(message.participantSid);
     }
     for (const v of message.trackSids) {
@@ -2178,10 +2163,8 @@ export const ParticipantTracks = {
 
   fromJSON(object: any): ParticipantTracks {
     return {
-      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
-      trackSids: Array.isArray(object?.trackSids)
-        ? object.trackSids.map((e: any) => String(e))
-        : [],
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : "",
+      trackSids: Array.isArray(object?.trackSids) ? object.trackSids.map((e: any) => String(e)) : [],
     };
   },
 
@@ -2198,14 +2181,14 @@ export const ParticipantTracks = {
 
   fromPartial<I extends Exact<DeepPartial<ParticipantTracks>, I>>(object: I): ParticipantTracks {
     const message = createBaseParticipantTracks();
-    message.participantSid = object.participantSid ?? '';
+    message.participantSid = object.participantSid ?? "";
     message.trackSids = object.trackSids?.map((e) => e) || [];
     return message;
   },
 };
 
 function createBaseServerInfo(): ServerInfo {
-  return { edition: 0, version: '', protocol: 0, region: '', nodeId: '', debugInfo: '' };
+  return { edition: 0, version: "", protocol: 0, region: "", nodeId: "", debugInfo: "" };
 }
 
 export const ServerInfo = {
@@ -2213,19 +2196,19 @@ export const ServerInfo = {
     if (message.edition !== 0) {
       writer.uint32(8).int32(message.edition);
     }
-    if (message.version !== '') {
+    if (message.version !== "") {
       writer.uint32(18).string(message.version);
     }
     if (message.protocol !== 0) {
       writer.uint32(24).int32(message.protocol);
     }
-    if (message.region !== '') {
+    if (message.region !== "") {
       writer.uint32(34).string(message.region);
     }
-    if (message.nodeId !== '') {
+    if (message.nodeId !== "") {
       writer.uint32(42).string(message.nodeId);
     }
-    if (message.debugInfo !== '') {
+    if (message.debugInfo !== "") {
       writer.uint32(50).string(message.debugInfo);
     }
     return writer;
@@ -2267,11 +2250,11 @@ export const ServerInfo = {
   fromJSON(object: any): ServerInfo {
     return {
       edition: isSet(object.edition) ? serverInfo_EditionFromJSON(object.edition) : 0,
-      version: isSet(object.version) ? String(object.version) : '',
+      version: isSet(object.version) ? String(object.version) : "",
       protocol: isSet(object.protocol) ? Number(object.protocol) : 0,
-      region: isSet(object.region) ? String(object.region) : '',
-      nodeId: isSet(object.nodeId) ? String(object.nodeId) : '',
-      debugInfo: isSet(object.debugInfo) ? String(object.debugInfo) : '',
+      region: isSet(object.region) ? String(object.region) : "",
+      nodeId: isSet(object.nodeId) ? String(object.nodeId) : "",
+      debugInfo: isSet(object.debugInfo) ? String(object.debugInfo) : "",
     };
   },
 
@@ -2289,11 +2272,11 @@ export const ServerInfo = {
   fromPartial<I extends Exact<DeepPartial<ServerInfo>, I>>(object: I): ServerInfo {
     const message = createBaseServerInfo();
     message.edition = object.edition ?? 0;
-    message.version = object.version ?? '';
+    message.version = object.version ?? "";
     message.protocol = object.protocol ?? 0;
-    message.region = object.region ?? '';
-    message.nodeId = object.nodeId ?? '';
-    message.debugInfo = object.debugInfo ?? '';
+    message.region = object.region ?? "";
+    message.nodeId = object.nodeId ?? "";
+    message.debugInfo = object.debugInfo ?? "";
     return message;
   },
 };
@@ -2301,15 +2284,15 @@ export const ServerInfo = {
 function createBaseClientInfo(): ClientInfo {
   return {
     sdk: 0,
-    version: '',
+    version: "",
     protocol: 0,
-    os: '',
-    osVersion: '',
-    deviceModel: '',
-    browser: '',
-    browserVersion: '',
-    address: '',
-    network: '',
+    os: "",
+    osVersion: "",
+    deviceModel: "",
+    browser: "",
+    browserVersion: "",
+    address: "",
+    network: "",
   };
 }
 
@@ -2318,31 +2301,31 @@ export const ClientInfo = {
     if (message.sdk !== 0) {
       writer.uint32(8).int32(message.sdk);
     }
-    if (message.version !== '') {
+    if (message.version !== "") {
       writer.uint32(18).string(message.version);
     }
     if (message.protocol !== 0) {
       writer.uint32(24).int32(message.protocol);
     }
-    if (message.os !== '') {
+    if (message.os !== "") {
       writer.uint32(34).string(message.os);
     }
-    if (message.osVersion !== '') {
+    if (message.osVersion !== "") {
       writer.uint32(42).string(message.osVersion);
     }
-    if (message.deviceModel !== '') {
+    if (message.deviceModel !== "") {
       writer.uint32(50).string(message.deviceModel);
     }
-    if (message.browser !== '') {
+    if (message.browser !== "") {
       writer.uint32(58).string(message.browser);
     }
-    if (message.browserVersion !== '') {
+    if (message.browserVersion !== "") {
       writer.uint32(66).string(message.browserVersion);
     }
-    if (message.address !== '') {
+    if (message.address !== "") {
       writer.uint32(74).string(message.address);
     }
-    if (message.network !== '') {
+    if (message.network !== "") {
       writer.uint32(82).string(message.network);
     }
     return writer;
@@ -2396,15 +2379,15 @@ export const ClientInfo = {
   fromJSON(object: any): ClientInfo {
     return {
       sdk: isSet(object.sdk) ? clientInfo_SDKFromJSON(object.sdk) : 0,
-      version: isSet(object.version) ? String(object.version) : '',
+      version: isSet(object.version) ? String(object.version) : "",
       protocol: isSet(object.protocol) ? Number(object.protocol) : 0,
-      os: isSet(object.os) ? String(object.os) : '',
-      osVersion: isSet(object.osVersion) ? String(object.osVersion) : '',
-      deviceModel: isSet(object.deviceModel) ? String(object.deviceModel) : '',
-      browser: isSet(object.browser) ? String(object.browser) : '',
-      browserVersion: isSet(object.browserVersion) ? String(object.browserVersion) : '',
-      address: isSet(object.address) ? String(object.address) : '',
-      network: isSet(object.network) ? String(object.network) : '',
+      os: isSet(object.os) ? String(object.os) : "",
+      osVersion: isSet(object.osVersion) ? String(object.osVersion) : "",
+      deviceModel: isSet(object.deviceModel) ? String(object.deviceModel) : "",
+      browser: isSet(object.browser) ? String(object.browser) : "",
+      browserVersion: isSet(object.browserVersion) ? String(object.browserVersion) : "",
+      address: isSet(object.address) ? String(object.address) : "",
+      network: isSet(object.network) ? String(object.network) : "",
     };
   },
 
@@ -2426,27 +2409,21 @@ export const ClientInfo = {
   fromPartial<I extends Exact<DeepPartial<ClientInfo>, I>>(object: I): ClientInfo {
     const message = createBaseClientInfo();
     message.sdk = object.sdk ?? 0;
-    message.version = object.version ?? '';
+    message.version = object.version ?? "";
     message.protocol = object.protocol ?? 0;
-    message.os = object.os ?? '';
-    message.osVersion = object.osVersion ?? '';
-    message.deviceModel = object.deviceModel ?? '';
-    message.browser = object.browser ?? '';
-    message.browserVersion = object.browserVersion ?? '';
-    message.address = object.address ?? '';
-    message.network = object.network ?? '';
+    message.os = object.os ?? "";
+    message.osVersion = object.osVersion ?? "";
+    message.deviceModel = object.deviceModel ?? "";
+    message.browser = object.browser ?? "";
+    message.browserVersion = object.browserVersion ?? "";
+    message.address = object.address ?? "";
+    message.network = object.network ?? "";
     return message;
   },
 };
 
 function createBaseClientConfiguration(): ClientConfiguration {
-  return {
-    video: undefined,
-    screen: undefined,
-    resumeConnection: 0,
-    disabledCodecs: undefined,
-    forceRelay: 0,
-  };
+  return { video: undefined, screen: undefined, resumeConnection: 0, disabledCodecs: undefined, forceRelay: 0 };
 }
 
 export const ClientConfiguration = {
@@ -2503,50 +2480,37 @@ export const ClientConfiguration = {
     return {
       video: isSet(object.video) ? VideoConfiguration.fromJSON(object.video) : undefined,
       screen: isSet(object.screen) ? VideoConfiguration.fromJSON(object.screen) : undefined,
-      resumeConnection: isSet(object.resumeConnection)
-        ? clientConfigSettingFromJSON(object.resumeConnection)
-        : 0,
-      disabledCodecs: isSet(object.disabledCodecs)
-        ? DisabledCodecs.fromJSON(object.disabledCodecs)
-        : undefined,
+      resumeConnection: isSet(object.resumeConnection) ? clientConfigSettingFromJSON(object.resumeConnection) : 0,
+      disabledCodecs: isSet(object.disabledCodecs) ? DisabledCodecs.fromJSON(object.disabledCodecs) : undefined,
       forceRelay: isSet(object.forceRelay) ? clientConfigSettingFromJSON(object.forceRelay) : 0,
     };
   },
 
   toJSON(message: ClientConfiguration): unknown {
     const obj: any = {};
-    message.video !== undefined &&
-      (obj.video = message.video ? VideoConfiguration.toJSON(message.video) : undefined);
+    message.video !== undefined && (obj.video = message.video ? VideoConfiguration.toJSON(message.video) : undefined);
     message.screen !== undefined &&
       (obj.screen = message.screen ? VideoConfiguration.toJSON(message.screen) : undefined);
     message.resumeConnection !== undefined &&
       (obj.resumeConnection = clientConfigSettingToJSON(message.resumeConnection));
     message.disabledCodecs !== undefined &&
-      (obj.disabledCodecs = message.disabledCodecs
-        ? DisabledCodecs.toJSON(message.disabledCodecs)
-        : undefined);
-    message.forceRelay !== undefined &&
-      (obj.forceRelay = clientConfigSettingToJSON(message.forceRelay));
+      (obj.disabledCodecs = message.disabledCodecs ? DisabledCodecs.toJSON(message.disabledCodecs) : undefined);
+    message.forceRelay !== undefined && (obj.forceRelay = clientConfigSettingToJSON(message.forceRelay));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ClientConfiguration>, I>>(
-    object: I,
-  ): ClientConfiguration {
+  fromPartial<I extends Exact<DeepPartial<ClientConfiguration>, I>>(object: I): ClientConfiguration {
     const message = createBaseClientConfiguration();
-    message.video =
-      object.video !== undefined && object.video !== null
-        ? VideoConfiguration.fromPartial(object.video)
-        : undefined;
-    message.screen =
-      object.screen !== undefined && object.screen !== null
-        ? VideoConfiguration.fromPartial(object.screen)
-        : undefined;
+    message.video = (object.video !== undefined && object.video !== null)
+      ? VideoConfiguration.fromPartial(object.video)
+      : undefined;
+    message.screen = (object.screen !== undefined && object.screen !== null)
+      ? VideoConfiguration.fromPartial(object.screen)
+      : undefined;
     message.resumeConnection = object.resumeConnection ?? 0;
-    message.disabledCodecs =
-      object.disabledCodecs !== undefined && object.disabledCodecs !== null
-        ? DisabledCodecs.fromPartial(object.disabledCodecs)
-        : undefined;
+    message.disabledCodecs = (object.disabledCodecs !== undefined && object.disabledCodecs !== null)
+      ? DisabledCodecs.fromPartial(object.disabledCodecs)
+      : undefined;
     message.forceRelay = object.forceRelay ?? 0;
     return message;
   },
@@ -2583,17 +2547,12 @@ export const VideoConfiguration = {
   },
 
   fromJSON(object: any): VideoConfiguration {
-    return {
-      hardwareEncoder: isSet(object.hardwareEncoder)
-        ? clientConfigSettingFromJSON(object.hardwareEncoder)
-        : 0,
-    };
+    return { hardwareEncoder: isSet(object.hardwareEncoder) ? clientConfigSettingFromJSON(object.hardwareEncoder) : 0 };
   },
 
   toJSON(message: VideoConfiguration): unknown {
     const obj: any = {};
-    message.hardwareEncoder !== undefined &&
-      (obj.hardwareEncoder = clientConfigSettingToJSON(message.hardwareEncoder));
+    message.hardwareEncoder !== undefined && (obj.hardwareEncoder = clientConfigSettingToJSON(message.hardwareEncoder));
     return obj;
   },
 
@@ -2643,21 +2602,19 @@ export const DisabledCodecs = {
   fromJSON(object: any): DisabledCodecs {
     return {
       codecs: Array.isArray(object?.codecs) ? object.codecs.map((e: any) => Codec.fromJSON(e)) : [],
-      publish: Array.isArray(object?.publish)
-        ? object.publish.map((e: any) => Codec.fromJSON(e))
-        : [],
+      publish: Array.isArray(object?.publish) ? object.publish.map((e: any) => Codec.fromJSON(e)) : [],
     };
   },
 
   toJSON(message: DisabledCodecs): unknown {
     const obj: any = {};
     if (message.codecs) {
-      obj.codecs = message.codecs.map((e) => (e ? Codec.toJSON(e) : undefined));
+      obj.codecs = message.codecs.map((e) => e ? Codec.toJSON(e) : undefined);
     } else {
       obj.codecs = [];
     }
     if (message.publish) {
-      obj.publish = message.publish.map((e) => (e ? Codec.toJSON(e) : undefined));
+      obj.publish = message.publish.map((e) => e ? Codec.toJSON(e) : undefined);
     } else {
       obj.publish = [];
     }
@@ -2801,10 +2758,7 @@ export const RTPStats = {
       writer.uint32(185).double(message.jitterMax);
     }
     Object.entries(message.gapHistogram).forEach(([key, value]) => {
-      RTPStats_GapHistogramEntry.encode(
-        { key: key as any, value },
-        writer.uint32(194).fork(),
-      ).ldelim();
+      RTPStats_GapHistogramEntry.encode({ key: key as any, value }, writer.uint32(194).fork()).ldelim();
     });
     if (message.nacks !== 0) {
       writer.uint32(200).uint32(message.nacks);
@@ -3016,17 +2970,11 @@ export const RTPStats = {
       bitrate: isSet(object.bitrate) ? Number(object.bitrate) : 0,
       packetsLost: isSet(object.packetsLost) ? Number(object.packetsLost) : 0,
       packetLossRate: isSet(object.packetLossRate) ? Number(object.packetLossRate) : 0,
-      packetLossPercentage: isSet(object.packetLossPercentage)
-        ? Number(object.packetLossPercentage)
-        : 0,
+      packetLossPercentage: isSet(object.packetLossPercentage) ? Number(object.packetLossPercentage) : 0,
       packetsDuplicate: isSet(object.packetsDuplicate) ? Number(object.packetsDuplicate) : 0,
-      packetDuplicateRate: isSet(object.packetDuplicateRate)
-        ? Number(object.packetDuplicateRate)
-        : 0,
+      packetDuplicateRate: isSet(object.packetDuplicateRate) ? Number(object.packetDuplicateRate) : 0,
       bytesDuplicate: isSet(object.bytesDuplicate) ? Number(object.bytesDuplicate) : 0,
-      headerBytesDuplicate: isSet(object.headerBytesDuplicate)
-        ? Number(object.headerBytesDuplicate)
-        : 0,
+      headerBytesDuplicate: isSet(object.headerBytesDuplicate) ? Number(object.headerBytesDuplicate) : 0,
       bitrateDuplicate: isSet(object.bitrateDuplicate) ? Number(object.bitrateDuplicate) : 0,
       packetsPadding: isSet(object.packetsPadding) ? Number(object.packetsPadding) : 0,
       packetPaddingRate: isSet(object.packetPaddingRate) ? Number(object.packetPaddingRate) : 0,
@@ -3039,13 +2987,10 @@ export const RTPStats = {
       jitterCurrent: isSet(object.jitterCurrent) ? Number(object.jitterCurrent) : 0,
       jitterMax: isSet(object.jitterMax) ? Number(object.jitterMax) : 0,
       gapHistogram: isObject(object.gapHistogram)
-        ? Object.entries(object.gapHistogram).reduce<{ [key: number]: number }>(
-            (acc, [key, value]) => {
-              acc[Number(key)] = Number(value);
-              return acc;
-            },
-            {},
-          )
+        ? Object.entries(object.gapHistogram).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+          acc[Number(key)] = Number(value);
+          return acc;
+        }, {})
         : {},
       nacks: isSet(object.nacks) ? Number(object.nacks) : 0,
       nackAcks: isSet(object.nackAcks) ? Number(object.nackAcks) : 0,
@@ -3060,9 +3005,7 @@ export const RTPStats = {
       keyFrames: isSet(object.keyFrames) ? Number(object.keyFrames) : 0,
       lastKeyFrame: isSet(object.lastKeyFrame) ? fromJsonTimestamp(object.lastKeyFrame) : undefined,
       layerLockPlis: isSet(object.layerLockPlis) ? Number(object.layerLockPlis) : 0,
-      lastLayerLockPli: isSet(object.lastLayerLockPli)
-        ? fromJsonTimestamp(object.lastLayerLockPli)
-        : undefined,
+      lastLayerLockPli: isSet(object.lastLayerLockPli) ? fromJsonTimestamp(object.lastLayerLockPli) : undefined,
       sampleRate: isSet(object.sampleRate) ? Number(object.sampleRate) : 0,
       driftMs: isSet(object.driftMs) ? Number(object.driftMs) : 0,
     };
@@ -3080,26 +3023,18 @@ export const RTPStats = {
     message.bitrate !== undefined && (obj.bitrate = message.bitrate);
     message.packetsLost !== undefined && (obj.packetsLost = Math.round(message.packetsLost));
     message.packetLossRate !== undefined && (obj.packetLossRate = message.packetLossRate);
-    message.packetLossPercentage !== undefined &&
-      (obj.packetLossPercentage = message.packetLossPercentage);
-    message.packetsDuplicate !== undefined &&
-      (obj.packetsDuplicate = Math.round(message.packetsDuplicate));
-    message.packetDuplicateRate !== undefined &&
-      (obj.packetDuplicateRate = message.packetDuplicateRate);
-    message.bytesDuplicate !== undefined &&
-      (obj.bytesDuplicate = Math.round(message.bytesDuplicate));
-    message.headerBytesDuplicate !== undefined &&
-      (obj.headerBytesDuplicate = Math.round(message.headerBytesDuplicate));
+    message.packetLossPercentage !== undefined && (obj.packetLossPercentage = message.packetLossPercentage);
+    message.packetsDuplicate !== undefined && (obj.packetsDuplicate = Math.round(message.packetsDuplicate));
+    message.packetDuplicateRate !== undefined && (obj.packetDuplicateRate = message.packetDuplicateRate);
+    message.bytesDuplicate !== undefined && (obj.bytesDuplicate = Math.round(message.bytesDuplicate));
+    message.headerBytesDuplicate !== undefined && (obj.headerBytesDuplicate = Math.round(message.headerBytesDuplicate));
     message.bitrateDuplicate !== undefined && (obj.bitrateDuplicate = message.bitrateDuplicate);
-    message.packetsPadding !== undefined &&
-      (obj.packetsPadding = Math.round(message.packetsPadding));
+    message.packetsPadding !== undefined && (obj.packetsPadding = Math.round(message.packetsPadding));
     message.packetPaddingRate !== undefined && (obj.packetPaddingRate = message.packetPaddingRate);
     message.bytesPadding !== undefined && (obj.bytesPadding = Math.round(message.bytesPadding));
-    message.headerBytesPadding !== undefined &&
-      (obj.headerBytesPadding = Math.round(message.headerBytesPadding));
+    message.headerBytesPadding !== undefined && (obj.headerBytesPadding = Math.round(message.headerBytesPadding));
     message.bitratePadding !== undefined && (obj.bitratePadding = message.bitratePadding);
-    message.packetsOutOfOrder !== undefined &&
-      (obj.packetsOutOfOrder = Math.round(message.packetsOutOfOrder));
+    message.packetsOutOfOrder !== undefined && (obj.packetsOutOfOrder = Math.round(message.packetsOutOfOrder));
     message.frames !== undefined && (obj.frames = Math.round(message.frames));
     message.frameRate !== undefined && (obj.frameRate = message.frameRate);
     message.jitterCurrent !== undefined && (obj.jitterCurrent = message.jitterCurrent);
@@ -3123,8 +3058,7 @@ export const RTPStats = {
     message.keyFrames !== undefined && (obj.keyFrames = Math.round(message.keyFrames));
     message.lastKeyFrame !== undefined && (obj.lastKeyFrame = message.lastKeyFrame.toISOString());
     message.layerLockPlis !== undefined && (obj.layerLockPlis = Math.round(message.layerLockPlis));
-    message.lastLayerLockPli !== undefined &&
-      (obj.lastLayerLockPli = message.lastLayerLockPli.toISOString());
+    message.lastLayerLockPli !== undefined && (obj.lastLayerLockPli = message.lastLayerLockPli.toISOString());
     message.sampleRate !== undefined && (obj.sampleRate = message.sampleRate);
     message.driftMs !== undefined && (obj.driftMs = message.driftMs);
     return obj;
@@ -3158,14 +3092,15 @@ export const RTPStats = {
     message.frameRate = object.frameRate ?? 0;
     message.jitterCurrent = object.jitterCurrent ?? 0;
     message.jitterMax = object.jitterMax ?? 0;
-    message.gapHistogram = Object.entries(object.gapHistogram ?? {}).reduce<{
-      [key: number]: number;
-    }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[Number(key)] = Number(value);
-      }
-      return acc;
-    }, {});
+    message.gapHistogram = Object.entries(object.gapHistogram ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {},
+    );
     message.nacks = object.nacks ?? 0;
     message.nackAcks = object.nackAcks ?? 0;
     message.nackMisses = object.nackMisses ?? 0;
@@ -3191,10 +3126,7 @@ function createBaseRTPStats_GapHistogramEntry(): RTPStats_GapHistogramEntry {
 }
 
 export const RTPStats_GapHistogramEntry = {
-  encode(
-    message: RTPStats_GapHistogramEntry,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
+  encode(message: RTPStats_GapHistogramEntry, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
     }
@@ -3226,10 +3158,7 @@ export const RTPStats_GapHistogramEntry = {
   },
 
   fromJSON(object: any): RTPStats_GapHistogramEntry {
-    return {
-      key: isSet(object.key) ? Number(object.key) : 0,
-      value: isSet(object.value) ? Number(object.value) : 0,
-    };
+    return { key: isSet(object.key) ? Number(object.key) : 0, value: isSet(object.value) ? Number(object.value) : 0 };
   },
 
   toJSON(message: RTPStats_GapHistogramEntry): unknown {
@@ -3239,9 +3168,7 @@ export const RTPStats_GapHistogramEntry = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<RTPStats_GapHistogramEntry>, I>>(
-    object: I,
-  ): RTPStats_GapHistogramEntry {
+  fromPartial<I extends Exact<DeepPartial<RTPStats_GapHistogramEntry>, I>>(object: I): RTPStats_GapHistogramEntry {
     const message = createBaseRTPStats_GapHistogramEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
@@ -3311,50 +3238,56 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
 })();
 
-const atob: (b64: string) => string =
-  globalThis.atob || ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
 function bytesFromBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const arr = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; ++i) {
-    arr[i] = bin.charCodeAt(i);
+  if (globalThis.Buffer) {
+    return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+  } else {
+    const bin = globalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
   }
-  return arr;
 }
 
-const btoa: (bin: string) => string =
-  globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
 function base64FromBytes(arr: Uint8Array): string {
-  const bin: string[] = [];
-  for (const byte of arr) {
-    bin.push(String.fromCharCode(byte));
+  if (globalThis.Buffer) {
+    return globalThis.Buffer.from(arr).toString("base64");
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return globalThis.btoa(bin.join(""));
   }
-  return btoa(bin.join(''));
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function toTimestamp(date: Date): Timestamp {
   const seconds = date.getTime() / 1_000;
@@ -3371,7 +3304,7 @@ function fromTimestamp(t: Timestamp): Date {
 function fromJsonTimestamp(o: any): Date {
   if (o instanceof Date) {
     return o;
-  } else if (typeof o === 'string') {
+  } else if (typeof o === "string") {
     return new Date(o);
   } else {
     return fromTimestamp(Timestamp.fromJSON(o));
@@ -3380,7 +3313,7 @@ function fromJsonTimestamp(o: any): Date {
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }
@@ -3391,7 +3324,7 @@ if (_m0.util.Long !== Long) {
 }
 
 function isObject(value: any): boolean {
-  return typeof value === 'object' && value !== null;
+  return typeof value === "object" && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/src/proto/livekit_room.ts
+++ b/src/proto/livekit_room.ts
@@ -1,19 +1,18 @@
 /* eslint-disable */
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
-import { RoomCompositeEgressRequest, AutoTrackEgress } from './livekit_egress';
+import _m0 from "protobufjs/minimal";
+import { AutoTrackEgress, RoomCompositeEgressRequest } from "./livekit_egress";
 import {
-  TrackInfo,
-  ParticipantPermission,
   DataPacket_Kind,
-  Room,
-  ParticipantInfo,
-  ParticipantTracks,
   dataPacket_KindFromJSON,
   dataPacket_KindToJSON,
-} from './livekit_models';
+  ParticipantInfo,
+  ParticipantPermission,
+  ParticipantTracks,
+  Room,
+  TrackInfo,
+} from "./livekit_models";
 
-export const protobufPackage = 'livekit';
+export const protobufPackage = "livekit";
 
 export interface CreateRoomRequest {
   /** name of the room */
@@ -49,7 +48,8 @@ export interface DeleteRoomRequest {
   room?: string;
 }
 
-export interface DeleteRoomResponse {}
+export interface DeleteRoomResponse {
+}
 
 export interface ListParticipantsRequest {
   /** name of the room */
@@ -67,7 +67,8 @@ export interface RoomParticipantIdentity {
   identity?: string;
 }
 
-export interface RemoveParticipantResponse {}
+export interface RemoveParticipantResponse {
+}
 
 export interface MuteRoomTrackRequest {
   /** name of the room */
@@ -106,7 +107,8 @@ export interface UpdateSubscriptionsRequest {
 }
 
 /** empty for now */
-export interface UpdateSubscriptionsResponse {}
+export interface UpdateSubscriptionsResponse {
+}
 
 export interface SendDataRequest {
   room?: string;
@@ -117,7 +119,8 @@ export interface SendDataRequest {
 }
 
 /**  */
-export interface SendDataResponse {}
+export interface SendDataResponse {
+}
 
 export interface UpdateRoomMetadataRequest {
   room?: string;
@@ -126,19 +129,12 @@ export interface UpdateRoomMetadataRequest {
 }
 
 function createBaseCreateRoomRequest(): CreateRoomRequest {
-  return {
-    name: '',
-    emptyTimeout: 0,
-    maxParticipants: 0,
-    nodeId: '',
-    metadata: '',
-    egress: undefined,
-  };
+  return { name: "", emptyTimeout: 0, maxParticipants: 0, nodeId: "", metadata: "", egress: undefined };
 }
 
 export const CreateRoomRequest = {
   encode(message: CreateRoomRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
     }
     if (message.emptyTimeout !== undefined && message.emptyTimeout !== 0) {
@@ -147,10 +143,10 @@ export const CreateRoomRequest = {
     if (message.maxParticipants !== undefined && message.maxParticipants !== 0) {
       writer.uint32(24).uint32(message.maxParticipants);
     }
-    if (message.nodeId !== undefined && message.nodeId !== '') {
+    if (message.nodeId !== undefined && message.nodeId !== "") {
       writer.uint32(34).string(message.nodeId);
     }
-    if (message.metadata !== undefined && message.metadata !== '') {
+    if (message.metadata !== undefined && message.metadata !== "") {
       writer.uint32(42).string(message.metadata);
     }
     if (message.egress !== undefined) {
@@ -194,11 +190,11 @@ export const CreateRoomRequest = {
 
   fromJSON(object: any): CreateRoomRequest {
     return {
-      name: isSet(object.name) ? String(object.name) : '',
+      name: isSet(object.name) ? String(object.name) : "",
       emptyTimeout: isSet(object.emptyTimeout) ? Number(object.emptyTimeout) : 0,
       maxParticipants: isSet(object.maxParticipants) ? Number(object.maxParticipants) : 0,
-      nodeId: isSet(object.nodeId) ? String(object.nodeId) : '',
-      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      nodeId: isSet(object.nodeId) ? String(object.nodeId) : "",
+      metadata: isSet(object.metadata) ? String(object.metadata) : "",
       egress: isSet(object.egress) ? RoomEgress.fromJSON(object.egress) : undefined,
     };
   },
@@ -207,26 +203,23 @@ export const CreateRoomRequest = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     message.emptyTimeout !== undefined && (obj.emptyTimeout = Math.round(message.emptyTimeout));
-    message.maxParticipants !== undefined &&
-      (obj.maxParticipants = Math.round(message.maxParticipants));
+    message.maxParticipants !== undefined && (obj.maxParticipants = Math.round(message.maxParticipants));
     message.nodeId !== undefined && (obj.nodeId = message.nodeId);
     message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.egress !== undefined &&
-      (obj.egress = message.egress ? RoomEgress.toJSON(message.egress) : undefined);
+    message.egress !== undefined && (obj.egress = message.egress ? RoomEgress.toJSON(message.egress) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<CreateRoomRequest>, I>>(object: I): CreateRoomRequest {
     const message = createBaseCreateRoomRequest();
-    message.name = object.name ?? '';
+    message.name = object.name ?? "";
     message.emptyTimeout = object.emptyTimeout ?? 0;
     message.maxParticipants = object.maxParticipants ?? 0;
-    message.nodeId = object.nodeId ?? '';
-    message.metadata = object.metadata ?? '';
-    message.egress =
-      object.egress !== undefined && object.egress !== null
-        ? RoomEgress.fromPartial(object.egress)
-        : undefined;
+    message.nodeId = object.nodeId ?? "";
+    message.metadata = object.metadata ?? "";
+    message.egress = (object.egress !== undefined && object.egress !== null)
+      ? RoomEgress.fromPartial(object.egress)
+      : undefined;
     return message;
   },
 };
@@ -278,21 +271,18 @@ export const RoomEgress = {
     const obj: any = {};
     message.room !== undefined &&
       (obj.room = message.room ? RoomCompositeEgressRequest.toJSON(message.room) : undefined);
-    message.tracks !== undefined &&
-      (obj.tracks = message.tracks ? AutoTrackEgress.toJSON(message.tracks) : undefined);
+    message.tracks !== undefined && (obj.tracks = message.tracks ? AutoTrackEgress.toJSON(message.tracks) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<RoomEgress>, I>>(object: I): RoomEgress {
     const message = createBaseRoomEgress();
-    message.room =
-      object.room !== undefined && object.room !== null
-        ? RoomCompositeEgressRequest.fromPartial(object.room)
-        : undefined;
-    message.tracks =
-      object.tracks !== undefined && object.tracks !== null
-        ? AutoTrackEgress.fromPartial(object.tracks)
-        : undefined;
+    message.room = (object.room !== undefined && object.room !== null)
+      ? RoomCompositeEgressRequest.fromPartial(object.room)
+      : undefined;
+    message.tracks = (object.tracks !== undefined && object.tracks !== null)
+      ? AutoTrackEgress.fromPartial(object.tracks)
+      : undefined;
     return message;
   },
 };
@@ -330,9 +320,7 @@ export const ListRoomsRequest = {
   },
 
   fromJSON(object: any): ListRoomsRequest {
-    return {
-      names: Array.isArray(object?.names) ? object.names.map((e: any) => String(e)) : [],
-    };
+    return { names: Array.isArray(object?.names) ? object.names.map((e: any) => String(e)) : [] };
   },
 
   toJSON(message: ListRoomsRequest): unknown {
@@ -385,15 +373,13 @@ export const ListRoomsResponse = {
   },
 
   fromJSON(object: any): ListRoomsResponse {
-    return {
-      rooms: Array.isArray(object?.rooms) ? object.rooms.map((e: any) => Room.fromJSON(e)) : [],
-    };
+    return { rooms: Array.isArray(object?.rooms) ? object.rooms.map((e: any) => Room.fromJSON(e)) : [] };
   },
 
   toJSON(message: ListRoomsResponse): unknown {
     const obj: any = {};
     if (message.rooms) {
-      obj.rooms = message.rooms.map((e) => (e ? Room.toJSON(e) : undefined));
+      obj.rooms = message.rooms.map((e) => e ? Room.toJSON(e) : undefined);
     } else {
       obj.rooms = [];
     }
@@ -408,12 +394,12 @@ export const ListRoomsResponse = {
 };
 
 function createBaseDeleteRoomRequest(): DeleteRoomRequest {
-  return { room: '' };
+  return { room: "" };
 }
 
 export const DeleteRoomRequest = {
   encode(message: DeleteRoomRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
     return writer;
@@ -438,9 +424,7 @@ export const DeleteRoomRequest = {
   },
 
   fromJSON(object: any): DeleteRoomRequest {
-    return {
-      room: isSet(object.room) ? String(object.room) : '',
-    };
+    return { room: isSet(object.room) ? String(object.room) : "" };
   },
 
   toJSON(message: DeleteRoomRequest): unknown {
@@ -451,7 +435,7 @@ export const DeleteRoomRequest = {
 
   fromPartial<I extends Exact<DeepPartial<DeleteRoomRequest>, I>>(object: I): DeleteRoomRequest {
     const message = createBaseDeleteRoomRequest();
-    message.room = object.room ?? '';
+    message.room = object.room ?? "";
     return message;
   },
 };
@@ -496,12 +480,12 @@ export const DeleteRoomResponse = {
 };
 
 function createBaseListParticipantsRequest(): ListParticipantsRequest {
-  return { room: '' };
+  return { room: "" };
 }
 
 export const ListParticipantsRequest = {
   encode(message: ListParticipantsRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
     return writer;
@@ -526,9 +510,7 @@ export const ListParticipantsRequest = {
   },
 
   fromJSON(object: any): ListParticipantsRequest {
-    return {
-      room: isSet(object.room) ? String(object.room) : '',
-    };
+    return { room: isSet(object.room) ? String(object.room) : "" };
   },
 
   toJSON(message: ListParticipantsRequest): unknown {
@@ -537,11 +519,9 @@ export const ListParticipantsRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ListParticipantsRequest>, I>>(
-    object: I,
-  ): ListParticipantsRequest {
+  fromPartial<I extends Exact<DeepPartial<ListParticipantsRequest>, I>>(object: I): ListParticipantsRequest {
     const message = createBaseListParticipantsRequest();
-    message.room = object.room ?? '';
+    message.room = object.room ?? "";
     return message;
   },
 };
@@ -589,18 +569,14 @@ export const ListParticipantsResponse = {
   toJSON(message: ListParticipantsResponse): unknown {
     const obj: any = {};
     if (message.participants) {
-      obj.participants = message.participants.map((e) =>
-        e ? ParticipantInfo.toJSON(e) : undefined,
-      );
+      obj.participants = message.participants.map((e) => e ? ParticipantInfo.toJSON(e) : undefined);
     } else {
       obj.participants = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ListParticipantsResponse>, I>>(
-    object: I,
-  ): ListParticipantsResponse {
+  fromPartial<I extends Exact<DeepPartial<ListParticipantsResponse>, I>>(object: I): ListParticipantsResponse {
     const message = createBaseListParticipantsResponse();
     message.participants = object.participants?.map((e) => ParticipantInfo.fromPartial(e)) || [];
     return message;
@@ -608,15 +584,15 @@ export const ListParticipantsResponse = {
 };
 
 function createBaseRoomParticipantIdentity(): RoomParticipantIdentity {
-  return { room: '', identity: '' };
+  return { room: "", identity: "" };
 }
 
 export const RoomParticipantIdentity = {
   encode(message: RoomParticipantIdentity, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
-    if (message.identity !== undefined && message.identity !== '') {
+    if (message.identity !== undefined && message.identity !== "") {
       writer.uint32(18).string(message.identity);
     }
     return writer;
@@ -645,8 +621,8 @@ export const RoomParticipantIdentity = {
 
   fromJSON(object: any): RoomParticipantIdentity {
     return {
-      room: isSet(object.room) ? String(object.room) : '',
-      identity: isSet(object.identity) ? String(object.identity) : '',
+      room: isSet(object.room) ? String(object.room) : "",
+      identity: isSet(object.identity) ? String(object.identity) : "",
     };
   },
 
@@ -657,12 +633,10 @@ export const RoomParticipantIdentity = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<RoomParticipantIdentity>, I>>(
-    object: I,
-  ): RoomParticipantIdentity {
+  fromPartial<I extends Exact<DeepPartial<RoomParticipantIdentity>, I>>(object: I): RoomParticipantIdentity {
     const message = createBaseRoomParticipantIdentity();
-    message.room = object.room ?? '';
-    message.identity = object.identity ?? '';
+    message.room = object.room ?? "";
+    message.identity = object.identity ?? "";
     return message;
   },
 };
@@ -700,27 +674,25 @@ export const RemoveParticipantResponse = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<RemoveParticipantResponse>, I>>(
-    _: I,
-  ): RemoveParticipantResponse {
+  fromPartial<I extends Exact<DeepPartial<RemoveParticipantResponse>, I>>(_: I): RemoveParticipantResponse {
     const message = createBaseRemoveParticipantResponse();
     return message;
   },
 };
 
 function createBaseMuteRoomTrackRequest(): MuteRoomTrackRequest {
-  return { room: '', identity: '', trackSid: '', muted: false };
+  return { room: "", identity: "", trackSid: "", muted: false };
 }
 
 export const MuteRoomTrackRequest = {
   encode(message: MuteRoomTrackRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
-    if (message.identity !== undefined && message.identity !== '') {
+    if (message.identity !== undefined && message.identity !== "") {
       writer.uint32(18).string(message.identity);
     }
-    if (message.trackSid !== undefined && message.trackSid !== '') {
+    if (message.trackSid !== undefined && message.trackSid !== "") {
       writer.uint32(26).string(message.trackSid);
     }
     if (message.muted === true) {
@@ -758,9 +730,9 @@ export const MuteRoomTrackRequest = {
 
   fromJSON(object: any): MuteRoomTrackRequest {
     return {
-      room: isSet(object.room) ? String(object.room) : '',
-      identity: isSet(object.identity) ? String(object.identity) : '',
-      trackSid: isSet(object.trackSid) ? String(object.trackSid) : '',
+      room: isSet(object.room) ? String(object.room) : "",
+      identity: isSet(object.identity) ? String(object.identity) : "",
+      trackSid: isSet(object.trackSid) ? String(object.trackSid) : "",
       muted: isSet(object.muted) ? Boolean(object.muted) : false,
     };
   },
@@ -774,13 +746,11 @@ export const MuteRoomTrackRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<MuteRoomTrackRequest>, I>>(
-    object: I,
-  ): MuteRoomTrackRequest {
+  fromPartial<I extends Exact<DeepPartial<MuteRoomTrackRequest>, I>>(object: I): MuteRoomTrackRequest {
     const message = createBaseMuteRoomTrackRequest();
-    message.room = object.room ?? '';
-    message.identity = object.identity ?? '';
-    message.trackSid = object.trackSid ?? '';
+    message.room = object.room ?? "";
+    message.identity = object.identity ?? "";
+    message.trackSid = object.trackSid ?? "";
     message.muted = object.muted ?? false;
     return message;
   },
@@ -817,49 +787,43 @@ export const MuteRoomTrackResponse = {
   },
 
   fromJSON(object: any): MuteRoomTrackResponse {
-    return {
-      track: isSet(object.track) ? TrackInfo.fromJSON(object.track) : undefined,
-    };
+    return { track: isSet(object.track) ? TrackInfo.fromJSON(object.track) : undefined };
   },
 
   toJSON(message: MuteRoomTrackResponse): unknown {
     const obj: any = {};
-    message.track !== undefined &&
-      (obj.track = message.track ? TrackInfo.toJSON(message.track) : undefined);
+    message.track !== undefined && (obj.track = message.track ? TrackInfo.toJSON(message.track) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<MuteRoomTrackResponse>, I>>(
-    object: I,
-  ): MuteRoomTrackResponse {
+  fromPartial<I extends Exact<DeepPartial<MuteRoomTrackResponse>, I>>(object: I): MuteRoomTrackResponse {
     const message = createBaseMuteRoomTrackResponse();
-    message.track =
-      object.track !== undefined && object.track !== null
-        ? TrackInfo.fromPartial(object.track)
-        : undefined;
+    message.track = (object.track !== undefined && object.track !== null)
+      ? TrackInfo.fromPartial(object.track)
+      : undefined;
     return message;
   },
 };
 
 function createBaseUpdateParticipantRequest(): UpdateParticipantRequest {
-  return { room: '', identity: '', metadata: '', permission: undefined, name: '' };
+  return { room: "", identity: "", metadata: "", permission: undefined, name: "" };
 }
 
 export const UpdateParticipantRequest = {
   encode(message: UpdateParticipantRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
-    if (message.identity !== undefined && message.identity !== '') {
+    if (message.identity !== undefined && message.identity !== "") {
       writer.uint32(18).string(message.identity);
     }
-    if (message.metadata !== undefined && message.metadata !== '') {
+    if (message.metadata !== undefined && message.metadata !== "") {
       writer.uint32(26).string(message.metadata);
     }
     if (message.permission !== undefined) {
       ParticipantPermission.encode(message.permission, writer.uint32(34).fork()).ldelim();
     }
-    if (message.name !== undefined && message.name !== '') {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(42).string(message.name);
     }
     return writer;
@@ -897,13 +861,11 @@ export const UpdateParticipantRequest = {
 
   fromJSON(object: any): UpdateParticipantRequest {
     return {
-      room: isSet(object.room) ? String(object.room) : '',
-      identity: isSet(object.identity) ? String(object.identity) : '',
-      metadata: isSet(object.metadata) ? String(object.metadata) : '',
-      permission: isSet(object.permission)
-        ? ParticipantPermission.fromJSON(object.permission)
-        : undefined,
-      name: isSet(object.name) ? String(object.name) : '',
+      room: isSet(object.room) ? String(object.room) : "",
+      identity: isSet(object.identity) ? String(object.identity) : "",
+      metadata: isSet(object.metadata) ? String(object.metadata) : "",
+      permission: isSet(object.permission) ? ParticipantPermission.fromJSON(object.permission) : undefined,
+      name: isSet(object.name) ? String(object.name) : "",
     };
   },
 
@@ -913,42 +875,34 @@ export const UpdateParticipantRequest = {
     message.identity !== undefined && (obj.identity = message.identity);
     message.metadata !== undefined && (obj.metadata = message.metadata);
     message.permission !== undefined &&
-      (obj.permission = message.permission
-        ? ParticipantPermission.toJSON(message.permission)
-        : undefined);
+      (obj.permission = message.permission ? ParticipantPermission.toJSON(message.permission) : undefined);
     message.name !== undefined && (obj.name = message.name);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateParticipantRequest>, I>>(
-    object: I,
-  ): UpdateParticipantRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdateParticipantRequest>, I>>(object: I): UpdateParticipantRequest {
     const message = createBaseUpdateParticipantRequest();
-    message.room = object.room ?? '';
-    message.identity = object.identity ?? '';
-    message.metadata = object.metadata ?? '';
-    message.permission =
-      object.permission !== undefined && object.permission !== null
-        ? ParticipantPermission.fromPartial(object.permission)
-        : undefined;
-    message.name = object.name ?? '';
+    message.room = object.room ?? "";
+    message.identity = object.identity ?? "";
+    message.metadata = object.metadata ?? "";
+    message.permission = (object.permission !== undefined && object.permission !== null)
+      ? ParticipantPermission.fromPartial(object.permission)
+      : undefined;
+    message.name = object.name ?? "";
     return message;
   },
 };
 
 function createBaseUpdateSubscriptionsRequest(): UpdateSubscriptionsRequest {
-  return { room: '', identity: '', trackSids: [], subscribe: false, participantTracks: [] };
+  return { room: "", identity: "", trackSids: [], subscribe: false, participantTracks: [] };
 }
 
 export const UpdateSubscriptionsRequest = {
-  encode(
-    message: UpdateSubscriptionsRequest,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+  encode(message: UpdateSubscriptionsRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
-    if (message.identity !== undefined && message.identity !== '') {
+    if (message.identity !== undefined && message.identity !== "") {
       writer.uint32(18).string(message.identity);
     }
     if (message.trackSids !== undefined && message.trackSids.length !== 0) {
@@ -999,11 +953,9 @@ export const UpdateSubscriptionsRequest = {
 
   fromJSON(object: any): UpdateSubscriptionsRequest {
     return {
-      room: isSet(object.room) ? String(object.room) : '',
-      identity: isSet(object.identity) ? String(object.identity) : '',
-      trackSids: Array.isArray(object?.trackSids)
-        ? object.trackSids.map((e: any) => String(e))
-        : [],
+      room: isSet(object.room) ? String(object.room) : "",
+      identity: isSet(object.identity) ? String(object.identity) : "",
+      trackSids: Array.isArray(object?.trackSids) ? object.trackSids.map((e: any) => String(e)) : [],
       subscribe: isSet(object.subscribe) ? Boolean(object.subscribe) : false,
       participantTracks: Array.isArray(object?.participantTracks)
         ? object.participantTracks.map((e: any) => ParticipantTracks.fromJSON(e))
@@ -1022,25 +974,20 @@ export const UpdateSubscriptionsRequest = {
     }
     message.subscribe !== undefined && (obj.subscribe = message.subscribe);
     if (message.participantTracks) {
-      obj.participantTracks = message.participantTracks.map((e) =>
-        e ? ParticipantTracks.toJSON(e) : undefined,
-      );
+      obj.participantTracks = message.participantTracks.map((e) => e ? ParticipantTracks.toJSON(e) : undefined);
     } else {
       obj.participantTracks = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateSubscriptionsRequest>, I>>(
-    object: I,
-  ): UpdateSubscriptionsRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdateSubscriptionsRequest>, I>>(object: I): UpdateSubscriptionsRequest {
     const message = createBaseUpdateSubscriptionsRequest();
-    message.room = object.room ?? '';
-    message.identity = object.identity ?? '';
+    message.room = object.room ?? "";
+    message.identity = object.identity ?? "";
     message.trackSids = object.trackSids?.map((e) => e) || [];
     message.subscribe = object.subscribe ?? false;
-    message.participantTracks =
-      object.participantTracks?.map((e) => ParticipantTracks.fromPartial(e)) || [];
+    message.participantTracks = object.participantTracks?.map((e) => ParticipantTracks.fromPartial(e)) || [];
     return message;
   },
 };
@@ -1078,21 +1025,19 @@ export const UpdateSubscriptionsResponse = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateSubscriptionsResponse>, I>>(
-    _: I,
-  ): UpdateSubscriptionsResponse {
+  fromPartial<I extends Exact<DeepPartial<UpdateSubscriptionsResponse>, I>>(_: I): UpdateSubscriptionsResponse {
     const message = createBaseUpdateSubscriptionsResponse();
     return message;
   },
 };
 
 function createBaseSendDataRequest(): SendDataRequest {
-  return { room: '', data: new Uint8Array(), kind: 0, destinationSids: [], topic: undefined };
+  return { room: "", data: new Uint8Array(), kind: 0, destinationSids: [], topic: undefined };
 }
 
 export const SendDataRequest = {
   encode(message: SendDataRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
     if (message.data !== undefined && message.data.length !== 0) {
@@ -1144,12 +1089,10 @@ export const SendDataRequest = {
 
   fromJSON(object: any): SendDataRequest {
     return {
-      room: isSet(object.room) ? String(object.room) : '',
+      room: isSet(object.room) ? String(object.room) : "",
       data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
       kind: isSet(object.kind) ? dataPacket_KindFromJSON(object.kind) : 0,
-      destinationSids: Array.isArray(object?.destinationSids)
-        ? object.destinationSids.map((e: any) => String(e))
-        : [],
+      destinationSids: Array.isArray(object?.destinationSids) ? object.destinationSids.map((e: any) => String(e)) : [],
       topic: isSet(object.topic) ? String(object.topic) : undefined,
     };
   },
@@ -1171,7 +1114,7 @@ export const SendDataRequest = {
 
   fromPartial<I extends Exact<DeepPartial<SendDataRequest>, I>>(object: I): SendDataRequest {
     const message = createBaseSendDataRequest();
-    message.room = object.room ?? '';
+    message.room = object.room ?? "";
     message.data = object.data ?? new Uint8Array();
     message.kind = object.kind ?? 0;
     message.destinationSids = object.destinationSids?.map((e) => e) || [];
@@ -1220,15 +1163,15 @@ export const SendDataResponse = {
 };
 
 function createBaseUpdateRoomMetadataRequest(): UpdateRoomMetadataRequest {
-  return { room: '', metadata: '' };
+  return { room: "", metadata: "" };
 }
 
 export const UpdateRoomMetadataRequest = {
   encode(message: UpdateRoomMetadataRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.room !== undefined && message.room !== '') {
+    if (message.room !== undefined && message.room !== "") {
       writer.uint32(10).string(message.room);
     }
-    if (message.metadata !== undefined && message.metadata !== '') {
+    if (message.metadata !== undefined && message.metadata !== "") {
       writer.uint32(18).string(message.metadata);
     }
     return writer;
@@ -1257,8 +1200,8 @@ export const UpdateRoomMetadataRequest = {
 
   fromJSON(object: any): UpdateRoomMetadataRequest {
     return {
-      room: isSet(object.room) ? String(object.room) : '',
-      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      room: isSet(object.room) ? String(object.room) : "",
+      metadata: isSet(object.metadata) ? String(object.metadata) : "",
     };
   },
 
@@ -1269,12 +1212,10 @@ export const UpdateRoomMetadataRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateRoomMetadataRequest>, I>>(
-    object: I,
-  ): UpdateRoomMetadataRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdateRoomMetadataRequest>, I>>(object: I): UpdateRoomMetadataRequest {
     const message = createBaseUpdateRoomMetadataRequest();
-    message.room = object.room ?? '';
-    message.metadata = object.metadata ?? '';
+    message.room = object.room ?? "";
+    message.metadata = object.metadata ?? "";
     return message;
   },
 };
@@ -1318,55 +1259,56 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
 })();
 
-const atob: (b64: string) => string =
-  globalThis.atob || ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
 function bytesFromBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const arr = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; ++i) {
-    arr[i] = bin.charCodeAt(i);
+  if (globalThis.Buffer) {
+    return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+  } else {
+    const bin = globalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
   }
-  return arr;
 }
 
-const btoa: (bin: string) => string =
-  globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
 function base64FromBytes(arr: Uint8Array): string {
-  const bin: string[] = [];
-  for (const byte of arr) {
-    bin.push(String.fromCharCode(byte));
+  if (globalThis.Buffer) {
+    return globalThis.Buffer.from(arr).toString("base64");
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return globalThis.btoa(bin.join(""));
   }
-  return btoa(bin.join(''));
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
-
-if (_m0.util.Long !== Long) {
-  _m0.util.Long = Long as any;
-  _m0.configure();
-}
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;

--- a/src/proto/livekit_webhook.ts
+++ b/src/proto/livekit_webhook.ts
@@ -1,11 +1,11 @@
 /* eslint-disable */
-import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
-import { Room, ParticipantInfo, TrackInfo } from './livekit_models';
-import { EgressInfo } from './livekit_egress';
-import { IngressInfo } from './livekit_ingress';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import { EgressInfo } from "./livekit_egress";
+import { IngressInfo } from "./livekit_ingress";
+import { ParticipantInfo, Room, TrackInfo } from "./livekit_models";
 
-export const protobufPackage = 'livekit';
+export const protobufPackage = "livekit";
 
 export interface WebhookEvent {
   /**
@@ -32,13 +32,13 @@ export interface WebhookEvent {
 
 function createBaseWebhookEvent(): WebhookEvent {
   return {
-    event: '',
+    event: "",
     room: undefined,
     participant: undefined,
     egressInfo: undefined,
     ingressInfo: undefined,
     track: undefined,
-    id: '',
+    id: "",
     createdAt: 0,
     numDropped: 0,
   };
@@ -46,7 +46,7 @@ function createBaseWebhookEvent(): WebhookEvent {
 
 export const WebhookEvent = {
   encode(message: WebhookEvent, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.event !== undefined && message.event !== '') {
+    if (message.event !== undefined && message.event !== "") {
       writer.uint32(10).string(message.event);
     }
     if (message.room !== undefined) {
@@ -64,7 +64,7 @@ export const WebhookEvent = {
     if (message.track !== undefined) {
       TrackInfo.encode(message.track, writer.uint32(66).fork()).ldelim();
     }
-    if (message.id !== undefined && message.id !== '') {
+    if (message.id !== undefined && message.id !== "") {
       writer.uint32(50).string(message.id);
     }
     if (message.createdAt !== undefined && message.createdAt !== 0) {
@@ -120,15 +120,13 @@ export const WebhookEvent = {
 
   fromJSON(object: any): WebhookEvent {
     return {
-      event: isSet(object.event) ? String(object.event) : '',
+      event: isSet(object.event) ? String(object.event) : "",
       room: isSet(object.room) ? Room.fromJSON(object.room) : undefined,
-      participant: isSet(object.participant)
-        ? ParticipantInfo.fromJSON(object.participant)
-        : undefined,
+      participant: isSet(object.participant) ? ParticipantInfo.fromJSON(object.participant) : undefined,
       egressInfo: isSet(object.egressInfo) ? EgressInfo.fromJSON(object.egressInfo) : undefined,
       ingressInfo: isSet(object.ingressInfo) ? IngressInfo.fromJSON(object.ingressInfo) : undefined,
       track: isSet(object.track) ? TrackInfo.fromJSON(object.track) : undefined,
-      id: isSet(object.id) ? String(object.id) : '',
+      id: isSet(object.id) ? String(object.id) : "",
       createdAt: isSet(object.createdAt) ? Number(object.createdAt) : 0,
       numDropped: isSet(object.numDropped) ? Number(object.numDropped) : 0,
     };
@@ -139,15 +137,12 @@ export const WebhookEvent = {
     message.event !== undefined && (obj.event = message.event);
     message.room !== undefined && (obj.room = message.room ? Room.toJSON(message.room) : undefined);
     message.participant !== undefined &&
-      (obj.participant = message.participant
-        ? ParticipantInfo.toJSON(message.participant)
-        : undefined);
+      (obj.participant = message.participant ? ParticipantInfo.toJSON(message.participant) : undefined);
     message.egressInfo !== undefined &&
       (obj.egressInfo = message.egressInfo ? EgressInfo.toJSON(message.egressInfo) : undefined);
     message.ingressInfo !== undefined &&
       (obj.ingressInfo = message.ingressInfo ? IngressInfo.toJSON(message.ingressInfo) : undefined);
-    message.track !== undefined &&
-      (obj.track = message.track ? TrackInfo.toJSON(message.track) : undefined);
+    message.track !== undefined && (obj.track = message.track ? TrackInfo.toJSON(message.track) : undefined);
     message.id !== undefined && (obj.id = message.id);
     message.createdAt !== undefined && (obj.createdAt = Math.round(message.createdAt));
     message.numDropped !== undefined && (obj.numDropped = Math.round(message.numDropped));
@@ -156,26 +151,21 @@ export const WebhookEvent = {
 
   fromPartial<I extends Exact<DeepPartial<WebhookEvent>, I>>(object: I): WebhookEvent {
     const message = createBaseWebhookEvent();
-    message.event = object.event ?? '';
-    message.room =
-      object.room !== undefined && object.room !== null ? Room.fromPartial(object.room) : undefined;
-    message.participant =
-      object.participant !== undefined && object.participant !== null
-        ? ParticipantInfo.fromPartial(object.participant)
-        : undefined;
-    message.egressInfo =
-      object.egressInfo !== undefined && object.egressInfo !== null
-        ? EgressInfo.fromPartial(object.egressInfo)
-        : undefined;
-    message.ingressInfo =
-      object.ingressInfo !== undefined && object.ingressInfo !== null
-        ? IngressInfo.fromPartial(object.ingressInfo)
-        : undefined;
-    message.track =
-      object.track !== undefined && object.track !== null
-        ? TrackInfo.fromPartial(object.track)
-        : undefined;
-    message.id = object.id ?? '';
+    message.event = object.event ?? "";
+    message.room = (object.room !== undefined && object.room !== null) ? Room.fromPartial(object.room) : undefined;
+    message.participant = (object.participant !== undefined && object.participant !== null)
+      ? ParticipantInfo.fromPartial(object.participant)
+      : undefined;
+    message.egressInfo = (object.egressInfo !== undefined && object.egressInfo !== null)
+      ? EgressInfo.fromPartial(object.egressInfo)
+      : undefined;
+    message.ingressInfo = (object.ingressInfo !== undefined && object.ingressInfo !== null)
+      ? IngressInfo.fromPartial(object.ingressInfo)
+      : undefined;
+    message.track = (object.track !== undefined && object.track !== null)
+      ? TrackInfo.fromPartial(object.track)
+      : undefined;
+    message.id = object.id ?? "";
     message.createdAt = object.createdAt ?? 0;
     message.numDropped = object.numDropped ?? 0;
     return message;
@@ -186,33 +176,35 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
 })();
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
   }
   return long.toNumber();
 }


### PR DESCRIPTION
Currently we are forcing users to provide all of the permission fields in an updateParticipant request. This is brittle since as new permission fields are introduced, they would require users' applications to be updated.