### PR TITLE
fix: delay processing of localTrackPublished event because of race condition

### DIFF
--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -334,8 +334,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       participant!.info.disconnectReason = ev.value.disconnectReason;
       this.emit(RoomEvent.ParticipantDisconnected, participant!);
     } else if (ev.case == 'localTrackPublished') {
-      const publication = this.localParticipant!.trackPublications.get(ev.value.trackSid!);
-      this.emit(RoomEvent.LocalTrackPublished, publication!, this.localParticipant!);
+      setImmediate(() => {
+        const publication = this.localParticipant!.trackPublications.get(ev.value.trackSid!);
+        this.emit(RoomEvent.LocalTrackPublished, publication!, this.localParticipant!);
+      });
     } else if (ev.case == 'localTrackUnpublished') {
       const publication = this.localParticipant!.trackPublications.get(ev.value.publicationSid!);
       this.localParticipant!.trackPublications.delete(ev.value.publicationSid!);


### PR DESCRIPTION
Maybe fixes #462 and #472. 

Without this, I cannot start an agent using Bun runtime.