### PR TITLE
fix: prevent listener leak in FfiClient.waitFor

### DIFF
--- a/.changeset/waitfor-listener-leak.md
+++ b/.changeset/waitfor-listener-leak.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Add timeout and abort support to FfiClient.waitFor to prevent listener leaks

--- a/packages/livekit-rtc/src/ffi_client.test.ts
+++ b/packages/livekit-rtc/src/ffi_client.test.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2025 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { FfiEvent } from '@livekit/rtc-ffi-bindings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FfiClient, FfiClientEvent } from './ffi_client.js';
+
+// We test waitFor by calling it directly on a plain FfiClient instance
+// (not the singleton) and manually emitting events.
+describe('FfiClient.waitFor', () => {
+  let client: FfiClient;
+
+  beforeEach(() => {
+    // Construct without triggering livekitInitialize by stubbing it
+    vi.mock(
+      '@livekit/rtc-ffi-bindings',
+      async (importOriginal) => {
+        const orig = await importOriginal<typeof import('@livekit/rtc-ffi-bindings')>();
+        return {
+          ...orig,
+          livekitInitialize: vi.fn(),
+        };
+      },
+    );
+    client = new FfiClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    client.removeAllListeners();
+  });
+
+  it('resolves when the predicate matches', async () => {
+    const event = new FfiEvent({
+      message: { case: 'connect', value: { asyncId: 1n } },
+    });
+
+    const promise = client.waitFor<{ asyncId: bigint }>(
+      (ev) => ev.message.case === 'connect',
+      { timeout: 1000 },
+    );
+
+    client.emit(FfiClientEvent.FfiEvent, event);
+
+    const result = await promise;
+    expect(result).toHaveProperty('asyncId');
+  });
+
+  it('removes the listener after the predicate matches', async () => {
+    const event = new FfiEvent({
+      message: { case: 'connect', value: { asyncId: 1n } },
+    });
+
+    const promise = client.waitFor(
+      (ev) => ev.message.case === 'connect',
+      { timeout: 1000 },
+    );
+
+    client.emit(FfiClientEvent.FfiEvent, event);
+    await promise;
+
+    expect(client.listenerCount(FfiClientEvent.FfiEvent)).toBe(0);
+  });
+
+  it('rejects with a timeout error when the predicate never matches', async () => {
+    const promise = client.waitFor(
+      () => false,
+      { timeout: 50 },
+    );
+
+    await expect(promise).rejects.toThrow('waitFor timed out');
+  });
+
+  it('removes the listener after timeout', async () => {
+    const promise = client.waitFor(
+      () => false,
+      { timeout: 50 },
+    );
+
+    await promise.catch(() => {});
+
+    expect(client.listenerCount(FfiClientEvent.FfiEvent)).toBe(0);
+  });
+
+  it('rejects when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled'));
+
+    const promise = client.waitFor(
+      () => true,
+      { signal: controller.signal },
+    );
+
+    await expect(promise).rejects.toThrow('cancelled');
+    expect(client.listenerCount(FfiClientEvent.FfiEvent)).toBe(0);
+  });
+
+  it('rejects when the signal is aborted while waiting', async () => {
+    const controller = new AbortController();
+
+    const promise = client.waitFor(
+      () => false,
+      { timeout: 5000, signal: controller.signal },
+    );
+
+    controller.abort(new Error('disconnect'));
+
+    await expect(promise).rejects.toThrow('disconnect');
+    expect(client.listenerCount(FfiClientEvent.FfiEvent)).toBe(0);
+  });
+});

--- a/packages/livekit-rtc/src/ffi_client.ts
+++ b/packages/livekit-rtc/src/ffi_client.ts
@@ -108,6 +108,7 @@ export class FfiClient extends (EventEmitter as new () => TypedEmitter<FfiClient
       };
 
       if (signal?.aborted) {
+        clearTimeout(timer);
         reject(signal.reason ?? new Error('waitFor aborted'));
         return;
       }

--- a/packages/livekit-rtc/src/ffi_client.ts
+++ b/packages/livekit-rtc/src/ffi_client.ts
@@ -70,14 +70,49 @@ export class FfiClient extends (EventEmitter as new () => TypedEmitter<FfiClient
     return livekitRetrievePtr(data);
   }
 
-  async waitFor<T>(predicate: (ev: FfiEvent) => boolean): Promise<T> {
-    return new Promise<T>((resolve) => {
+  static defaultTimeout = 10000;
+
+  async waitFor<T>(
+    predicate: (ev: FfiEvent) => boolean,
+    { timeout = FfiClient.defaultTimeout, signal }: { timeout?: number; signal?: AbortSignal } = {},
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = () => {
+        settled = true;
+        this.off(FfiClientEvent.FfiEvent, listener);
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+      };
+
       const listener = (ev: FfiEvent) => {
         if (predicate(ev)) {
-          this.off(FfiClientEvent.FfiEvent, listener);
+          cleanup();
           resolve(ev.message.value as T);
         }
       };
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          cleanup();
+          reject(new Error('waitFor timed out'));
+        }
+      }, timeout);
+
+      const onAbort = () => {
+        if (!settled) {
+          cleanup();
+          reject(signal!.reason ?? new Error('waitFor aborted'));
+        }
+      };
+
+      if (signal?.aborted) {
+        reject(signal.reason ?? new Error('waitFor aborted'));
+        return;
+      }
+
+      signal?.addEventListener('abort', onAbort);
       this.on(FfiClientEvent.FfiEvent, listener);
     });
   }


### PR DESCRIPTION
The `waitFor` method on `FfiClient` registers an event listener that is only removed when the predicate matches. If the native FFI layer never sends the expected callback — due to network disconnect, native crash, or `room.disconnect()` being called while operations are in-flight — the listener stays attached to the process-global `FfiClient` singleton forever. Each orphaned listener continues running its predicate against every future FFI event, leaking memory and wasting CPU.

This change adds two cleanup mechanisms to `waitFor`:

- **Timeout** (default 10s via `FfiClient.defaultTimeout`): if the expected event never arrives, the listener is removed and the promise rejects with a descriptive error. The default is configurable per-call.
- **AbortSignal**: callers can pass an `AbortSignal` to cancel pending `waitFor` operations externally, enabling patterns like cancelling all in-flight operations on disconnect.

Both parameters are optional and backward-compatible — existing call sites continue to work without changes, now with automatic cleanup after 10 seconds.