### PR TITLE
Fix ReadableStream lock leak in stream readers

### DIFF
--- a/.changeset/stream-reader-lock-leak.md
+++ b/.changeset/stream-reader-lock-leak.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Fix ReadableStream lock leak in ByteStreamReader and TextStreamReader

--- a/packages/livekit-rtc/src/data_streams/stream_reader.ts
+++ b/packages/livekit-rtc/src/data_streams/stream_reader.ts
@@ -53,6 +53,7 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
         try {
           const { done, value } = await reader.read();
           if (done) {
+            reader.releaseLock();
             return { done: true, value: undefined as unknown };
           } else {
             this.handleChunkReceived(value);
@@ -60,12 +61,17 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
           }
         } catch (error: unknown) {
           log.error('error processing stream update: %s', error);
+          reader.releaseLock();
           return { done: true, value: undefined as unknown };
         }
       },
 
       return(): IteratorResult<Uint8Array> {
-        reader.releaseLock();
+        try {
+          reader.releaseLock();
+        } catch {
+          // already released
+        }
         return { done: true, value: undefined };
       },
     };
@@ -127,6 +133,7 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
         try {
           const { done, value } = await reader.read();
           if (done) {
+            reader.releaseLock();
             return { done: true, value: undefined };
           } else {
             this.handleChunkReceived(value);
@@ -137,12 +144,17 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
           }
         } catch (error: unknown) {
           log.error('error processing stream update: %s', error);
+          reader.releaseLock();
           return { done: true, value: undefined };
         }
       },
 
       return(): IteratorResult<string> {
-        reader.releaseLock();
+        try {
+          reader.releaseLock();
+        } catch {
+          // already released
+        }
         return { done: true, value: undefined };
       },
     };

--- a/packages/livekit-rtc/src/tests/stream_reader.test.ts
+++ b/packages/livekit-rtc/src/tests/stream_reader.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2024 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ByteStreamReader, TextStreamReader } from '../data_streams/stream_reader.js';
+import type { ByteStreamInfo, TextStreamInfo } from '../data_streams/types.js';
+
+const encoder = new TextEncoder();
+
+function makeChunk(text: string, index: number = 0) {
+  return {
+    content: encoder.encode(text),
+    chunkIndex: BigInt(index),
+    version: 1,
+  } as any;
+}
+
+const byteInfo: ByteStreamInfo = {
+  streamId: 'test-stream',
+  mimeType: 'application/octet-stream',
+  topic: 'test',
+  timestamp: Date.now(),
+  name: 'test-file',
+};
+
+const textInfo: TextStreamInfo = {
+  streamId: 'test-stream',
+  mimeType: 'text/plain',
+  topic: 'test',
+  timestamp: Date.now(),
+};
+
+describe('ByteStreamReader', () => {
+  it('should release the ReadableStream lock after normal iteration completes', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(makeChunk('hello'));
+        controller.enqueue(makeChunk('world'));
+        controller.close();
+      },
+    });
+
+    const reader = new ByteStreamReader(byteInfo, stream as any);
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(2);
+    // Stream should be unlocked — getting a new reader should not throw
+    const newReader = stream.getReader();
+    newReader.releaseLock();
+  });
+
+  it('should release the ReadableStream lock when reader.read() throws', async () => {
+    let callCount = 0;
+    const stream = new ReadableStream({
+      pull(controller) {
+        callCount++;
+        if (callCount === 1) {
+          controller.enqueue(makeChunk('ok'));
+        } else {
+          controller.error(new Error('simulated failure'));
+        }
+      },
+    });
+
+    const reader = new ByteStreamReader(byteInfo, stream as any);
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    // Stream should be unlocked after error path
+    const newReader = stream.getReader();
+    newReader.releaseLock();
+  });
+
+  it('should release the ReadableStream lock after readAll() completes', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(makeChunk('a'));
+        controller.enqueue(makeChunk('b'));
+        controller.close();
+      },
+    });
+
+    const reader = new ByteStreamReader(byteInfo, stream as any);
+    const result = await reader.readAll();
+
+    expect(result).toHaveLength(2);
+    // Stream should be unlocked
+    const newReader = stream.getReader();
+    newReader.releaseLock();
+  });
+});
+
+describe('TextStreamReader', () => {
+  it('should release the ReadableStream lock after normal iteration completes', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(makeChunk('hello', 0));
+        controller.enqueue(makeChunk(' world', 1));
+        controller.close();
+      },
+    });
+
+    const reader = new TextStreamReader(textInfo, stream as any);
+    const texts: string[] = [];
+    for await (const text of reader) {
+      texts.push(text);
+    }
+
+    expect(texts).toHaveLength(2);
+    // Stream should be unlocked
+    const newReader = stream.getReader();
+    newReader.releaseLock();
+  });
+
+  it('should release the ReadableStream lock when reader.read() throws', async () => {
+    let callCount = 0;
+    const stream = new ReadableStream({
+      pull(controller) {
+        callCount++;
+        if (callCount === 1) {
+          controller.enqueue(makeChunk('ok', 0));
+        } else {
+          controller.error(new Error('simulated failure'));
+        }
+      },
+    });
+
+    const reader = new TextStreamReader(textInfo, stream as any);
+    const texts: string[] = [];
+    for await (const text of reader) {
+      texts.push(text);
+    }
+
+    expect(texts).toHaveLength(1);
+    // Stream should be unlocked after error path
+    const newReader = stream.getReader();
+    newReader.releaseLock();
+  });
+
+  it('should release the ReadableStream lock after readAll() completes', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(makeChunk('hello', 0));
+        controller.enqueue(makeChunk(' world', 1));
+        controller.close();
+      },
+    });
+
+    const reader = new TextStreamReader(textInfo, stream as any);
+    const result = await reader.readAll();
+
+    expect(result).toBe('hello world');
+    // Stream should be unlocked
+    const newReader = stream.getReader();
+    newReader.releaseLock();
+  });
+});


### PR DESCRIPTION
Both `ByteStreamReader` and `TextStreamReader` implement `[Symbol.asyncIterator]` with a `return()` method that calls `reader.releaseLock()`. However, per the ECMAScript spec, `for await...of` only calls `return()` when the loop exits **abruptly** (via break, return, or throw from the loop body). When `next()` returns `{ done: true }` — either on normal stream completion or in the error catch block — the loop ends normally and `return()` is never invoked. This leaves the `ReadableStream` permanently locked.

The fix calls `reader.releaseLock()` in `next()` whenever returning `{ done: true }`, covering both the normal completion path and the error path. The `return()` method is wrapped in a try/catch so it remains idempotent when the lock was already released by `next()`.