### PR TITLE
fix(leak): Memory leak when Room.connect() fails

### DIFF
--- a/.changeset/connect-error-listener-leak.md
+++ b/.changeset/connect-error-listener-leak.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Remove FfiClient listener on failed connect to prevent leak

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -235,49 +235,55 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
 
     FfiClient.instance.on(FfiClientEvent.FfiEvent, this.onFfiEvent);
 
-    const res = FfiClient.instance.request<ConnectResponse>({
-      message: {
-        case: 'connect',
-        value: req,
-      },
-    });
+    try {
+      const res = FfiClient.instance.request<ConnectResponse>({
+        message: {
+          case: 'connect',
+          value: req,
+        },
+      });
 
-    const cb = await FfiClient.instance.waitFor<ConnectCallback>((ev: FfiEvent) => {
-      return ev.message.case == 'connect' && ev.message.value.asyncId == res.asyncId;
-    });
+      const cb = await FfiClient.instance.waitFor<ConnectCallback>((ev: FfiEvent) => {
+        return ev.message.case == 'connect' && ev.message.value.asyncId == res.asyncId;
+      });
 
-    log.debug('Connect callback received');
+      log.debug('Connect callback received');
 
-    switch (cb.message.case) {
-      case 'result':
-        this.ffiHandle = new FfiHandle(cb.message.value.room!.handle!.id!);
-        this.e2eeManager = e2eeEnabled && new E2EEManager(this.ffiHandle.handle, e2eeOptions);
+      switch (cb.message.case) {
+        case 'result':
+          this.ffiHandle = new FfiHandle(cb.message.value.room!.handle!.id!);
+          this.e2eeManager = e2eeEnabled && new E2EEManager(this.ffiHandle.handle, e2eeOptions);
 
-        this._token = token;
-        this._serverUrl = url;
-        this.info = cb.message.value.room!.info;
-        this.connectionState = ConnectionState.CONN_CONNECTED;
-        // Reset the abort controller for this connection session so that
-        // a previous disconnect doesn't immediately cancel new operations.
-        this.disconnectController = new AbortController();
-        this.localParticipant = new LocalParticipant(
-          cb.message.value.localParticipant!,
-          this.ffiEventLock,
-          this.disconnectController.signal,
-        );
+          this._token = token;
+          this._serverUrl = url;
+          this.info = cb.message.value.room!.info;
+          this.connectionState = ConnectionState.CONN_CONNECTED;
+          // Reset the abort controller for this connection session so that
+          // a previous disconnect doesn't immediately cancel new operations.
+          this.disconnectController = new AbortController();
+          this.localParticipant = new LocalParticipant(
+            cb.message.value.localParticipant!,
+            this.ffiEventLock,
+            this.disconnectController.signal,
+          );
 
-        for (const pt of cb.message.value.participants) {
-          const rp = this.createRemoteParticipant(pt.participant!);
+          for (const pt of cb.message.value.participants) {
+            const rp = this.createRemoteParticipant(pt.participant!);
 
-          for (const pub of pt.publications) {
-            const publication = new RemoteTrackPublication(pub);
-            rp.trackPublications.set(publication.sid!, publication);
+            for (const pub of pt.publications) {
+              const publication = new RemoteTrackPublication(pub);
+              rp.trackPublications.set(publication.sid!, publication);
+            }
           }
-        }
-        break;
-      case 'error':
-      default:
-        throw new ConnectError(cb.message.value || '');
+          break;
+        case 'error':
+        default:
+          throw new ConnectError(cb.message.value || '');
+      }
+    } catch (e) {
+      FfiClient.instance.off(FfiClientEvent.FfiEvent, this.onFfiEvent);
+      this.preConnectEvents = [];
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Summary

When `Room.connect()` fails, the `onFfiEvent` listener registered on the global `FfiClient` singleton is never removed. This causes two problems:

- **The Room instance cannot be garbage collected** because `FfiClient` holds a reference to `this.onFfiEvent`, which closes over the Room.
- **`preConnectEvents` grows unboundedly** because `onFfiEvent` keeps pushing every `FfiEvent` into the array — the guard `!this.localParticipant || !this.ffiHandle || !this.info` is always true for a Room that never finished connecting.
- **Retrying `connect()` on the same Room multiplies the leak**, since each failed attempt adds another copy of the listener.

The fix wraps the connect logic in a `try/catch` so that on any error (whether from `waitFor` rejection or the `ConnectError` thrown on the `'error'` case), we:

1. Remove the `onFfiEvent` listener from `FfiClient`
2. Clear the `preConnectEvents` array

The listener is intentionally **not** removed on the success path — it must stay attached for the room to function normally.