### PR TITLE
Update ffi bindings

### DIFF
--- a/.changeset/sharp-bobcats-cut.md
+++ b/.changeset/sharp-bobcats-cut.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Add support for rpc v2

--- a/packages/livekit-rtc/package.json
+++ b/packages/livekit-rtc/package.json
@@ -32,19 +32,19 @@
   "dependencies": {
     "@datastructures-js/deque": "1.0.8",
     "@livekit/mutex": "^1.0.0",
+    "@livekit/rtc-ffi-bindings": "0.12.59",
     "@livekit/typed-emitter": "^3.0.0",
-    "@livekit/rtc-ffi-bindings": "0.12.56",
     "pino": "^9.0.0",
     "pino-pretty": "^13.0.0"
   },
   "devDependencies": {
     "@bufbuild/protobuf": "^1.10.1",
     "@types/node": "^22.13.10",
-    "vitest": "^3.0.0",
+    "livekit-server-sdk": "workspace:*",
     "prettier": "^3.0.3",
     "tsup": "^8.3.5",
     "typescript": "5.8.2",
-    "livekit-server-sdk": "workspace:*"
+    "vitest": "^3.0.0"
   },
   "engines": {
     "node": ">= 18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: ^1.0.0
         version: 1.1.1
       '@livekit/rtc-ffi-bindings':
-        specifier: 0.12.56
-        version: 0.12.56
+        specifier: 0.12.59
+        version: 0.12.59
       '@livekit/typed-emitter':
         specifier: ^3.0.0
         version: 3.0.0
@@ -965,40 +965,40 @@ packages:
   '@livekit/protocol@1.45.6':
     resolution: {integrity: sha512-YPDmrUiVe1EY/q/2bD+Fp+69DWq6LZgeH+G/KEbz07OIVf8hgAYzfb1FgiOdWLRpSj06+SuTmrOY604fWNuD3w==}
 
-  '@livekit/rtc-ffi-bindings-darwin-arm64@0.12.56':
-    resolution: {integrity: sha512-ohKFUgZPpXGrtinfbgYML/P7n+ov4IXLx1jyL6p/xcpsgVQfFdLR0tRxmFfBypbcnfaBZMpgosOzV+/IgK2ddg==}
+  '@livekit/rtc-ffi-bindings-darwin-arm64@0.12.59':
+    resolution: {integrity: sha512-K6TqcchR32d7Pjhp0jSpQD7v6mzuL0nRdI6ccIFZe01/aUn7ZbGm+Dt9NsK8ErhxUza8i1UJdClptx8+15yjKw==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@livekit/rtc-ffi-bindings-darwin-x64@0.12.56':
-    resolution: {integrity: sha512-q1scIsnbV2BQhktSpE/YSqni8NgJk/iExD6ASb4LdXU0jbibdwePs07A0SmO+/Sn7ROqQApFGeg2xDIXzACK/w==}
+  '@livekit/rtc-ffi-bindings-darwin-x64@0.12.59':
+    resolution: {integrity: sha512-hxbe+g2wVMTD+706BU49UEtI+Q4oqU2EXuAzX/r0A4hGa0KoJkZy7nZBKBvX9243rOHtt3h4Sd3W8Q5C8IrknQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [darwin]
 
-  '@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.56':
-    resolution: {integrity: sha512-Wk+68CyWWiDYmB3XKkw7nOpidh+RgwE2Dfag5KBazzjgC2Nj0m1pReXlDMgKGPByaVTrVmphER3gs8phPx5Rzw==}
+  '@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.59':
+    resolution: {integrity: sha512-AMDN9/CwmP+qI00BvVph84AtRQNF5yAy5rUpKj7km8tOsnApqUCz6EAQI4LmW7Qp4udg9U/30rIwWfdBcILCCw==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.56':
-    resolution: {integrity: sha512-fF0USwEkELhnVFBEgYUCHT50qfug3VluzforlEL5MKBn8/gu8m12MGckq9K1zkOsuA9jNhLVUhrSpSgaCowbTw==}
+  '@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.59':
+    resolution: {integrity: sha512-x39lx1YXTZUmuj8yLBOBcU3roW5qf/IgYYxa9uuu00hQ1flDbL8U0J0jyjpmDe8RX321i3euRoydHQM8hMepgA==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.56':
-    resolution: {integrity: sha512-uPK1k43h7HHt2rhRObVNLhhH+x3YvA8DPcTMP8OpRwMeq16TdD/44BdgFKvmlHQoJJfzMFty74MyEkr4nTdqAw==}
+  '@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.59':
+    resolution: {integrity: sha512-WjFb1k6TI7PHLPY083d/DUs6Ri6jtv3QUtYTbhIXvD+dY9rTMR5beN9AN8rXivX6WzquWtWuRrQfEWaU8BBKIA==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [win32]
 
-  '@livekit/rtc-ffi-bindings@0.12.56':
-    resolution: {integrity: sha512-BCirumGTO7iQYk2KidsqraSNqCbveYGBEQGJS/9lMSeJOFXwwlWHWL9N9ZThBNjAdCQdcvSthWB33FApob8H1w==}
+  '@livekit/rtc-ffi-bindings@0.12.59':
+    resolution: {integrity: sha512-I0snu2+khYOrf1NWogozQNVrEtI/1Sf+qcI/t89FZyOQ5/C1KwNnmrZ2BnqztyzYZmMHj8UpcYu0cxNRWoZ14w==}
     engines: {node: '>= 18'}
 
   '@livekit/typed-emitter@3.0.0':
@@ -1699,9 +1699,11 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4624,30 +4626,30 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
-  '@livekit/rtc-ffi-bindings-darwin-arm64@0.12.56':
+  '@livekit/rtc-ffi-bindings-darwin-arm64@0.12.59':
     optional: true
 
-  '@livekit/rtc-ffi-bindings-darwin-x64@0.12.56':
+  '@livekit/rtc-ffi-bindings-darwin-x64@0.12.59':
     optional: true
 
-  '@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.56':
+  '@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.59':
     optional: true
 
-  '@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.56':
+  '@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.59':
     optional: true
 
-  '@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.56':
+  '@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.59':
     optional: true
 
-  '@livekit/rtc-ffi-bindings@0.12.56':
+  '@livekit/rtc-ffi-bindings@0.12.59':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
     optionalDependencies:
-      '@livekit/rtc-ffi-bindings-darwin-arm64': 0.12.56
-      '@livekit/rtc-ffi-bindings-darwin-x64': 0.12.56
-      '@livekit/rtc-ffi-bindings-linux-arm64-gnu': 0.12.56
-      '@livekit/rtc-ffi-bindings-linux-x64-gnu': 0.12.56
-      '@livekit/rtc-ffi-bindings-win32-x64-msvc': 0.12.56
+      '@livekit/rtc-ffi-bindings-darwin-arm64': 0.12.59
+      '@livekit/rtc-ffi-bindings-darwin-x64': 0.12.59
+      '@livekit/rtc-ffi-bindings-linux-arm64-gnu': 0.12.59
+      '@livekit/rtc-ffi-bindings-linux-x64-gnu': 0.12.59
+      '@livekit/rtc-ffi-bindings-win32-x64-msvc': 0.12.59
 
   '@livekit/typed-emitter@3.0.0': {}
 


### PR DESCRIPTION
Updates `livekit-ffi` bindings to `0.12.59` to add [support for rpc v2](https://github.com/livekit/rust-sdks/pull/1013).

# TODO
- [ ] Final local integration testing