### PR TITLE
Fix bug where a local audio track unpublish would not cause the corresponding remote audio track's `AudioStream`s to stop iterating

### DIFF
--- a/.changeset/proud-pianos-joke.md
+++ b/.changeset/proud-pianos-joke.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Add initial support for frame processor usage directly on tracks

--- a/packages/livekit-rtc/src/audio_stream.ts
+++ b/packages/livekit-rtc/src/audio_stream.ts
@@ -134,16 +134,6 @@ export class AudioStreamSource implements UnderlyingSource<AudioFrame> {
     this.teardown();
   }
 
-  /**
-   * Tear down this stream from the Track side — used when the track has been
-   * unsubscribed remotely and there will be no more frames. Closes the
-   * controller so any in flight async iterators by downstream consumers terminate.
-   * @internal
-   */
-  closeFromTrack(): void {
-    this.teardown();
-  }
-
   private teardown(): void {
     if (this.disposed) return;
     this.disposed = true;

--- a/packages/livekit-rtc/src/audio_stream.ts
+++ b/packages/livekit-rtc/src/audio_stream.ts
@@ -13,6 +13,12 @@ import type { Track } from './track.js';
 
 export interface AudioStreamOptions {
   noiseCancellation?: NoiseCancellationOptions | FrameProcessor<AudioFrame>;
+  /**
+   * If true and `noiseCancellation` is a {@link FrameProcessor}, leaves the
+   * processor open when the stream closes so the same processor can be reused
+   * with another {@link AudioStream}. Defaults to `false`.
+   */
+  noiseCancellationLeaveOpen?: boolean;
   sampleRate?: number;
   numChannels?: number;
   frameSizeMs?: number;
@@ -31,19 +37,23 @@ class AudioStreamSource implements UnderlyingSource<AudioFrame> {
   private sampleRate: number;
   private numChannels: number;
   private legacyNcOptions?: NoiseCancellationOptions;
-  private frameProcessor?: FrameProcessor<AudioFrame>;
+  private frameProcessor: FrameProcessor<AudioFrame> | null = null;
+  private leaveProcessorOpen = false;
   private frameSizeMs?: number;
+  private track: Track;
 
   constructor(
     track: Track,
     sampleRateOrOptions?: number | AudioStreamOptions,
     numChannels?: number,
   ) {
+    this.track = track;
     if (sampleRateOrOptions !== undefined && typeof sampleRateOrOptions !== 'number') {
       this.sampleRate = sampleRateOrOptions.sampleRate ?? 48000;
       this.numChannels = sampleRateOrOptions.numChannels ?? 1;
       if (isFrameProcessor(sampleRateOrOptions.noiseCancellation)) {
         this.frameProcessor = sampleRateOrOptions.noiseCancellation;
+        this.leaveProcessorOpen = sampleRateOrOptions.noiseCancellationLeaveOpen ?? false;
       } else {
         this.legacyNcOptions = sampleRateOrOptions.noiseCancellation;
       }
@@ -77,6 +87,12 @@ class AudioStreamSource implements UnderlyingSource<AudioFrame> {
     this.ffiHandle = new FfiHandle(res.stream!.handle!.id!);
 
     FfiClient.instance.on(FfiClientEvent.FfiEvent, this.onEvent);
+    track.registerAudioStream(this);
+  }
+
+  /** @internal */
+  get processor(): FrameProcessor<AudioFrame> | null {
+    return this.frameProcessor;
   }
 
   private onEvent = (ev: FfiEvent) => {
@@ -113,8 +129,11 @@ class AudioStreamSource implements UnderlyingSource<AudioFrame> {
         // while buffered frames are still in the ReadableStream queue.
         if (!this.disposed) {
           this.disposed = true;
+          this.track.unregisterAudioStream(this);
           this.ffiHandle.dispose();
-          this.frameProcessor?.close();
+          if (this.frameProcessor && !this.leaveProcessorOpen) {
+            this.frameProcessor.close();
+          }
         }
         break;
     }
@@ -128,10 +147,13 @@ class AudioStreamSource implements UnderlyingSource<AudioFrame> {
     FfiClient.instance.off(FfiClientEvent.FfiEvent, this.onEvent);
     if (!this.disposed) {
       this.disposed = true;
+      this.track.unregisterAudioStream(this);
       this.ffiHandle.dispose();
       // Also close the frame processor on cancel for symmetry with the EOS path,
       // so resources are released regardless of how the stream ends.
-      this.frameProcessor?.close();
+      if (this.frameProcessor && !this.leaveProcessorOpen) {
+        this.frameProcessor.close();
+      }
     }
   }
 }

--- a/packages/livekit-rtc/src/audio_stream.ts
+++ b/packages/livekit-rtc/src/audio_stream.ts
@@ -30,7 +30,7 @@ export interface NoiseCancellationOptions {
   options: Record<string, any>;
 }
 
-class AudioStreamSource implements UnderlyingSource<AudioFrame> {
+export class AudioStreamSource implements UnderlyingSource<AudioFrame> {
   private controller?: ReadableStreamDefaultController<AudioFrame>;
   private ffiHandle: FfiHandle;
   private disposed = false;

--- a/packages/livekit-rtc/src/audio_stream.ts
+++ b/packages/livekit-rtc/src/audio_stream.ts
@@ -121,20 +121,7 @@ export class AudioStreamSource implements UnderlyingSource<AudioFrame> {
         this.controller.enqueue(frame);
         break;
       case 'eos':
-        FfiClient.instance.off(FfiClientEvent.FfiEvent, this.onEvent);
-        this.controller.close();
-        // Dispose the native handle so the FD is released on stream end,
-        // not just when cancel() is called explicitly by the consumer.
-        // Guard against double-dispose if cancel() is called after EOS
-        // while buffered frames are still in the ReadableStream queue.
-        if (!this.disposed) {
-          this.disposed = true;
-          this.track.unregisterAudioStream(this);
-          this.ffiHandle.dispose();
-          if (this.frameProcessor && !this.leaveProcessorOpen) {
-            this.frameProcessor.close();
-          }
-        }
+        this.teardown();
         break;
     }
   };
@@ -144,16 +131,36 @@ export class AudioStreamSource implements UnderlyingSource<AudioFrame> {
   }
 
   cancel() {
+    this.teardown();
+  }
+
+  /**
+   * Tear down this stream from the Track side — used when the track has been
+   * unsubscribed remotely and there will be no more frames. Closes the
+   * controller so any in flight async iterators by downstream consumers terminate.
+   * @internal
+   */
+  closeFromTrack(): void {
+    this.teardown();
+  }
+
+  private teardown(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    // Close the controller FIRST so any pending reader.read() resolves with
+    // {done:true} and consumer-side `for await` / `iterator.return()` can
+    // unblock. The native EOS event (if it ever arrives) would do this for us,
+    // but we can't count on it firing for remote-unsubscribe scenarios.
+    try {
+      this.controller?.close();
+    } catch {
+      // Controller may already be closed if EOS arrived first; ignore.
+    }
     FfiClient.instance.off(FfiClientEvent.FfiEvent, this.onEvent);
-    if (!this.disposed) {
-      this.disposed = true;
-      this.track.unregisterAudioStream(this);
-      this.ffiHandle.dispose();
-      // Also close the frame processor on cancel for symmetry with the EOS path,
-      // so resources are released regardless of how the stream ends.
-      if (this.frameProcessor && !this.leaveProcessorOpen) {
-        this.frameProcessor.close();
-      }
+    this.track.unregisterAudioStream(this);
+    this.ffiHandle.dispose();
+    if (this.frameProcessor && !this.leaveProcessorOpen) {
+      this.frameProcessor.close();
     }
   }
 }

--- a/packages/livekit-rtc/src/frame_processor.ts
+++ b/packages/livekit-rtc/src/frame_processor.ts
@@ -43,7 +43,11 @@ export abstract class FrameProcessor<Frame extends VideoFrame | AudioFrame> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onStreamInfoUpdated(_info: FrameProcessorStreamInfo): void {}
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onStreamInfoCleared(): void {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onCredentialsUpdated(_credentials: FrameProcessorCredentials): void {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onCredentialsCleared(): void {}
 
   abstract process(frame: Frame): Frame;
   abstract close(): void;

--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -547,9 +547,15 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       }
     } else if (ev.case == 'localTrackPublished') {
       const publication = this.localParticipant.trackPublications.get(ev.value.trackSid!);
+      if (publication?.track) {
+        publication.track.setRoom(this);
+      }
       this.emit(RoomEvent.LocalTrackPublished, publication!, this.localParticipant);
     } else if (ev.case == 'localTrackUnpublished') {
       const publication = this.localParticipant.trackPublications.get(ev.value.publicationSid!);
+      if (publication?.track) {
+        publication.track.setRoom(null);
+      }
       this.localParticipant.trackPublications.delete(ev.value.publicationSid!);
       this.emit(RoomEvent.LocalTrackUnpublished, publication!, this.localParticipant!);
     } else if ((ev.case as string) == 'localTrackRepublished') {
@@ -610,6 +616,7 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
         } else if (trackInfo.kind == TrackKind.KIND_AUDIO) {
           publication.track = new RemoteAudioTrack(ownedTrack);
         }
+        publication.track?.setRoom(this);
 
         this.emit(RoomEvent.TrackSubscribed, publication.track!, publication, participant);
       } catch (e: unknown) {
@@ -622,6 +629,7 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
           ev.value.trackSid!,
         );
         const track = publication.track!;
+        track.setRoom(null);
         publication.track = undefined;
         publication.subscribed = false;
         this.emit(RoomEvent.TrackUnsubscribed, track, publication, participant);

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -56,13 +56,12 @@ export abstract class Track {
   /** @internal */
   setRoom(room: Room | null): void {
     const oldRoom = this.resolveRoom();
-    if (oldRoom !== room) {
-      if (oldRoom) {
-        oldRoom.off('tokenRefreshed', this.onRoomTokenRefreshed);
-      }
-      if (room) {
-        room.on('tokenRefreshed', this.onRoomTokenRefreshed);
-      }
+    if (oldRoom && oldRoom !== room) {
+      oldRoom.off('tokenRefreshed', this.onRoomTokenRefreshed);
+    }
+    if (room) {
+      room.off('tokenRefreshed', this.onRoomTokenRefreshed);
+      room.on('tokenRefreshed', this.onRoomTokenRefreshed);
     }
     this.roomRef = room ? new WeakRef(room) : null;
     for (const stream of this.iterateStreams()) {

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -105,20 +105,23 @@ export abstract class Track {
     }
   }
 
-  private pushProcessorMetadataToStream(stream: AudioStreamSource, room: Room | null): void {
-    const processor = stream.processor;
-    if (!processor) {
-      return;
-    }
-
+  private pushProcessorMetadataToStream(stream: AudioStreamLike, room: Room | null): void {
     if (!room) {
       // Guard with optional-call: plugins built against an older @livekit/rtc-node
       // inherit a FrameProcessor base class that doesn't define these methods,
       // so they could be undefined on the prototype chain.
-      processor.onStreamInfoCleared?.();
-      processor.onCredentialsCleared?.();
+      // still alive — the subsequent closeFromTrack may invoke processor.close().
+      stream.processor?.onStreamInfoCleared?.();
+      stream.processor?.onCredentialsCleared?.();
+      // Tell the stream the track left the room — no more frames will arrive
+      // (the remote peer has unsubscribed), so close it so consumers' `for
+      // await` loops can terminate.
+      stream.closeFromTrack?.();
       return;
     }
+
+    const processor = stream.processor;
+    if (!processor) return;
 
     let identity = '';
     let publicationSid = '';

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -10,9 +10,17 @@ import type {
   TrackKind,
 } from '@livekit/rtc-ffi-bindings';
 import { CreateAudioTrackRequest, CreateVideoTrackRequest } from '@livekit/rtc-ffi-bindings';
+import type { AudioFrame } from './audio_frame.js';
 import type { AudioSource } from './audio_source.js';
 import { FfiClient, FfiHandle } from './ffi_client.js';
+import type { FrameProcessor } from './frame_processor.js';
+import type { Room } from './room.js';
 import type { VideoSource } from './video_source.js';
+
+/** @internal */
+export interface AudioStreamLike {
+  readonly processor: FrameProcessor<AudioFrame> | null;
+}
 
 export abstract class Track {
   /** @internal */
@@ -21,9 +29,131 @@ export abstract class Track {
   /** @internal */
   ffi_handle: FfiHandle;
 
+  private roomRef: WeakRef<Room> | null = null;
+  private audioStreams: Set<WeakRef<AudioStreamLike>> = new Set();
+  private streamFinalizationRegistry: FinalizationRegistry<WeakRef<AudioStreamLike>>;
+  private onRoomTokenRefreshed = () => {
+    const room = this.resolveRoom();
+    if (!room || !room.token || !room.serverUrl) return;
+    for (const stream of this.iterateStreams()) {
+      const processor = stream.processor;
+      if (!processor) continue;
+      processor.onCredentialsUpdated({ token: room.token, url: room.serverUrl });
+    }
+  };
+
   constructor(owned: OwnedTrack) {
     this.info = owned.info;
     this.ffi_handle = new FfiHandle(owned.handle!.id!);
+    this.streamFinalizationRegistry = new FinalizationRegistry<WeakRef<AudioStreamLike>>((ref) => {
+      this.audioStreams.delete(ref);
+    });
+  }
+
+  /** @internal */
+  resolveRoom(): Room | null {
+    return this.roomRef?.deref() ?? null;
+  }
+
+  /** @internal */
+  setRoom(room: Room | null): void {
+    const oldRoom = this.resolveRoom();
+    if (oldRoom !== room) {
+      if (oldRoom) {
+        oldRoom.off('tokenRefreshed', this.onRoomTokenRefreshed);
+      }
+      if (room) {
+        room.on('tokenRefreshed', this.onRoomTokenRefreshed);
+      }
+    }
+    this.roomRef = room ? new WeakRef(room) : null;
+    for (const stream of this.iterateStreams()) {
+      this.pushProcessorMetadataToStream(stream, room);
+    }
+  }
+
+  /** @internal */
+  registerAudioStream(stream: AudioStreamLike): void {
+    const ref = new WeakRef(stream);
+    this.audioStreams.add(ref);
+    this.streamFinalizationRegistry.register(stream, ref);
+    const room = this.resolveRoom();
+    if (room) {
+      this.pushProcessorMetadataToStream(stream, room);
+    }
+  }
+
+  /** @internal */
+  unregisterAudioStream(stream: AudioStreamLike): void {
+    for (const ref of this.audioStreams) {
+      if (ref.deref() === stream) {
+        this.audioStreams.delete(ref);
+        return;
+      }
+    }
+  }
+
+  private *iterateStreams(): Generator<AudioStreamLike> {
+    const dead: Array<WeakRef<AudioStreamLike>> = [];
+    for (const ref of this.audioStreams) {
+      const stream = ref.deref();
+      if (stream) {
+        yield stream;
+      } else {
+        dead.push(ref);
+      }
+    }
+    for (const ref of dead) {
+      this.audioStreams.delete(ref);
+    }
+  }
+
+  private pushProcessorMetadataToStream(stream: AudioStreamLike, room: Room | null): void {
+    const processor = stream.processor;
+    if (!processor) return;
+
+    if (!room) {
+      processor.onStreamInfoCleared();
+      processor.onCredentialsCleared();
+      return;
+    }
+
+    let identity = '';
+    let publicationSid = '';
+    const trackSid = this.sid;
+    if (trackSid) {
+      let found = false;
+      for (const participant of room.remoteParticipants.values()) {
+        const publication = participant.trackPublications.get(trackSid);
+        if (publication) {
+          identity = participant.identity;
+          publicationSid = publication.sid ?? '';
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        const local = room.localParticipant;
+        if (local) {
+          for (const publication of local.trackPublications.values()) {
+            if (publication.sid === trackSid) {
+              identity = local.identity;
+              publicationSid = publication.sid ?? '';
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    processor.onStreamInfoUpdated({
+      roomName: room.name ?? '',
+      participantIdentity: identity,
+      publicationSid,
+    });
+    if (room.token && room.serverUrl) {
+      processor.onCredentialsUpdated({ token: room.token, url: room.serverUrl });
+    }
   }
 
   get sid(): string | undefined {

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -113,8 +113,11 @@ export abstract class Track {
     if (!processor) return;
 
     if (!room) {
-      processor.onStreamInfoCleared();
-      processor.onCredentialsCleared();
+      // Guard with optional-call: plugins built against an older @livekit/rtc-node
+      // inherit a FrameProcessor base class that doesn't define these methods,
+      // so they could be undefined on the prototype chain.
+      processor.onStreamInfoCleared?.();
+      processor.onCredentialsCleared?.();
       return;
     }
 

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -105,18 +105,18 @@ export abstract class Track {
     }
   }
 
-  private pushProcessorMetadataToStream(stream: AudioStreamLike, room: Room | null): void {
+  private pushProcessorMetadataToStream(stream: AudioStreamSource, room: Room | null): void {
     if (!room) {
       // Guard with optional-call: plugins built against an older @livekit/rtc-node
       // inherit a FrameProcessor base class that doesn't define these methods,
       // so they could be undefined on the prototype chain.
-      // still alive — the subsequent closeFromTrack may invoke processor.close().
+      // still alive — the subsequent cancel may invoke processor.close().
       stream.processor?.onStreamInfoCleared?.();
       stream.processor?.onCredentialsCleared?.();
       // Tell the stream the track left the room — no more frames will arrive
-      // (the remote peer has unsubscribed), so close it so consumers' `for
+      // (the remote peer has unsubscribed), so cancel it so consumers' `for
       // await` loops can terminate.
-      stream.closeFromTrack?.();
+      stream.cancel();
       return;
     }
 

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -11,10 +11,10 @@ import type {
 } from '@livekit/rtc-ffi-bindings';
 import { CreateAudioTrackRequest, CreateVideoTrackRequest } from '@livekit/rtc-ffi-bindings';
 import type { AudioSource } from './audio_source.js';
+import type { AudioStreamSource } from './audio_stream.js';
 import { FfiClient, FfiHandle } from './ffi_client.js';
 import type { Room } from './room.js';
 import type { VideoSource } from './video_source.js';
-import type { AudioStreamSource } from './audio_stream.js';
 
 export abstract class Track {
   /** @internal */
@@ -31,7 +31,9 @@ export abstract class Track {
     if (!room || !room.token || !room.serverUrl) return;
     for (const stream of this.iterateStreams()) {
       const processor = stream.processor;
-      if (!processor) continue;
+      if (!processor) {
+        continue;
+      }
       processor.onCredentialsUpdated({ token: room.token, url: room.serverUrl });
     }
   };
@@ -39,9 +41,11 @@ export abstract class Track {
   constructor(owned: OwnedTrack) {
     this.info = owned.info;
     this.ffi_handle = new FfiHandle(owned.handle!.id!);
-    this.streamFinalizationRegistry = new FinalizationRegistry<WeakRef<AudioStreamSource>>((ref) => {
-      this.audioStreams.delete(ref);
-    });
+    this.streamFinalizationRegistry = new FinalizationRegistry<WeakRef<AudioStreamSource>>(
+      (ref) => {
+        this.audioStreams.delete(ref);
+      },
+    );
   }
 
   /** @internal */
@@ -104,7 +108,9 @@ export abstract class Track {
 
   private pushProcessorMetadataToStream(stream: AudioStreamSource, room: Room | null): void {
     const processor = stream.processor;
-    if (!processor) return;
+    if (!processor) {
+      return;
+    }
 
     if (!room) {
       // Guard with optional-call: plugins built against an older @livekit/rtc-node

--- a/packages/livekit-rtc/src/track.ts
+++ b/packages/livekit-rtc/src/track.ts
@@ -10,17 +10,11 @@ import type {
   TrackKind,
 } from '@livekit/rtc-ffi-bindings';
 import { CreateAudioTrackRequest, CreateVideoTrackRequest } from '@livekit/rtc-ffi-bindings';
-import type { AudioFrame } from './audio_frame.js';
 import type { AudioSource } from './audio_source.js';
 import { FfiClient, FfiHandle } from './ffi_client.js';
-import type { FrameProcessor } from './frame_processor.js';
 import type { Room } from './room.js';
 import type { VideoSource } from './video_source.js';
-
-/** @internal */
-export interface AudioStreamLike {
-  readonly processor: FrameProcessor<AudioFrame> | null;
-}
+import type { AudioStreamSource } from './audio_stream.js';
 
 export abstract class Track {
   /** @internal */
@@ -30,8 +24,8 @@ export abstract class Track {
   ffi_handle: FfiHandle;
 
   private roomRef: WeakRef<Room> | null = null;
-  private audioStreams: Set<WeakRef<AudioStreamLike>> = new Set();
-  private streamFinalizationRegistry: FinalizationRegistry<WeakRef<AudioStreamLike>>;
+  private audioStreams: Set<WeakRef<AudioStreamSource>> = new Set();
+  private streamFinalizationRegistry: FinalizationRegistry<WeakRef<AudioStreamSource>>;
   private onRoomTokenRefreshed = () => {
     const room = this.resolveRoom();
     if (!room || !room.token || !room.serverUrl) return;
@@ -45,7 +39,7 @@ export abstract class Track {
   constructor(owned: OwnedTrack) {
     this.info = owned.info;
     this.ffi_handle = new FfiHandle(owned.handle!.id!);
-    this.streamFinalizationRegistry = new FinalizationRegistry<WeakRef<AudioStreamLike>>((ref) => {
+    this.streamFinalizationRegistry = new FinalizationRegistry<WeakRef<AudioStreamSource>>((ref) => {
       this.audioStreams.delete(ref);
     });
   }
@@ -73,7 +67,7 @@ export abstract class Track {
   }
 
   /** @internal */
-  registerAudioStream(stream: AudioStreamLike): void {
+  registerAudioStream(stream: AudioStreamSource): void {
     const ref = new WeakRef(stream);
     this.audioStreams.add(ref);
     this.streamFinalizationRegistry.register(stream, ref);
@@ -84,7 +78,7 @@ export abstract class Track {
   }
 
   /** @internal */
-  unregisterAudioStream(stream: AudioStreamLike): void {
+  unregisterAudioStream(stream: AudioStreamSource): void {
     for (const ref of this.audioStreams) {
       if (ref.deref() === stream) {
         this.audioStreams.delete(ref);
@@ -93,8 +87,8 @@ export abstract class Track {
     }
   }
 
-  private *iterateStreams(): Generator<AudioStreamLike> {
-    const dead: Array<WeakRef<AudioStreamLike>> = [];
+  private *iterateStreams(): Generator<AudioStreamSource> {
+    const dead: Array<WeakRef<AudioStreamSource>> = [];
     for (const ref of this.audioStreams) {
       const stream = ref.deref();
       if (stream) {
@@ -108,7 +102,7 @@ export abstract class Track {
     }
   }
 
-  private pushProcessorMetadataToStream(stream: AudioStreamLike, room: Room | null): void {
+  private pushProcessorMetadataToStream(stream: AudioStreamSource, room: Room | null): void {
     const processor = stream.processor;
     if (!processor) return;
 

--- a/packages/livekit-rtc/tsconfig.json
+++ b/packages/livekit-rtc/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "lib": ["es2015", "es2021.weakref"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts", "vite.config.ts"]


### PR DESCRIPTION
> [!WARNING]
> Right now, this pull request is based on top of another one [here](https://github.com/livekit/node-sdks/pull/671), and ties into some of this pull request's new infrastructure.
>
> Before an eventual merge, this needs to be cleaned up. But keep this in mind when reviewing - the changes which are specific to this change cleanly are segmented into 28da338 and c31a6ee.

## Problem

When a remote peer unpublishes an audio track, a subscriber consuming the resulting `AudioStream` via `for await (const frame of stream)` hangs indefinitely - the loop never receives an end-of-stream and the process can't exit. Calling `iterator.return()` or `stream.cancel()` to force termination doesn't help either - the in flight promise returned by `reader.read()` never resolves.

## Root cause

The native FFI side only emits `eos` on the audio stream when one of: (a) the stream's own FFI handle is disposed, (b) the *track's* FFI handle is disposed, or (c) the underlying libwebrtc receiver gracefully ends. None of these reliably fire on a remote unsubscribe - the SDK keeps the track handle alive (the consumer may still want to read `track.sid` etc.), and (according to a LLM) the libwebrtc receiver typically keeps the stream "open" with silence rather than ending it.

On the SDK side, `AudioStreamSource.cancel()` previously disposed the FFI handle but never closed the `ReadableStream` controller. The native `eos` (if it ever arrived) would have triggered the close - but since the event listener was removed at the top of `cancel()`, even a late `eos` was silently dropped. So any pending `reader.read()` had nothing to resolve it.

## Fix

Two changes in `packages/livekit-rtc/src/`:

1. **`audio_stream.ts`**: collapse the three cleanup paths (`'eos'` event, consumer `cancel()`, and a new `closeFromTrack()` entry point) into one `teardown()` method that closes the `ReadableStreamDefaultController` first. Closing the controller synchronously resolves any pending `reader.read()` with `{done: true}`, so `for await` / `iterator.return()` unblock without relying on the native `eos` arriving.

2. **`track.ts`**: when a `Track` is detached from its `Room` (the natural signal that no more frames will arrive on its streams), call `closeFromTrack()` on each registered `AudioStream`. This gives consumers a clean end-of-stream even when the native layer doesn't emit one.

## TODO
- [ ] Add new tests specifically for this case
- [ ] More through manual testing
