### PR TITLE
feat: auto failover APIs with LK Cloud

### DIFF
--- a/.changeset/wet-dryers-matter.md
+++ b/.changeset/wet-dryers-matter.md
@@ -1,0 +1,5 @@
+---
+"livekit-server-sdk": patch
+---
+
+feat: auto failover APIs with LK Cloud

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test API
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  failover:
+    runs-on: ubuntu-latest
+    services:
+      mock-server:
+        image: livekit/test-server:latest
+        ports:
+          - 9999:9999
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Wait for mock server
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:9999/settings/regions >/dev/null && exit 0
+            sleep 1
+          done
+          echo "mock server did not become ready" && exit 1
+
+      - name: Run API tests
+        run: pnpm --filter="livekit-server-sdk" exec vitest --environment node run test/api

--- a/packages/livekit-server-sdk/package.json
+++ b/packages/livekit-server-sdk/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.1",
     "@livekit/protocol": "^1.46.6",
-    "camelcase-keys": "^9.0.0",
     "jose": "^5.1.2"
   },
   "devDependencies": {

--- a/packages/livekit-server-sdk/src/AgentDispatchClient.ts
+++ b/packages/livekit-server-sdk/src/AgentDispatchClient.ts
@@ -40,10 +40,10 @@ export class AgentDispatchClient extends ServiceBase {
    */
   constructor(host: string, apiKey?: string, secret?: string, options?: ClientOptions) {
     super(apiKey, secret);
-    const rpcOptions = options?.requestTimeout
-      ? { requestTimeout: options.requestTimeout }
-      : undefined;
-    this.rpc = new TwirpRpc(host, livekitPackage, rpcOptions);
+    this.rpc = new TwirpRpc(host, livekitPackage, {
+      requestTimeout: options?.requestTimeout,
+      failover: options?.failover,
+    });
   }
 
   /**

--- a/packages/livekit-server-sdk/src/ClientOptions.ts
+++ b/packages/livekit-server-sdk/src/ClientOptions.ts
@@ -12,8 +12,9 @@ export type ClientOptions = {
    */
   requestTimeout?: number;
   /**
-   * Region-failover behavior for API requests. Defaults to auto, which fails
-   * over to alternative regions for LiveKit Cloud hosts on retryable errors.
+   * Region-failover tuning for API requests. Omit it (the default) to enable
+   * failover for LiveKit Cloud hosts only; pass a config to enable it for any
+   * host. Set `maxAttempts: 1` to disable.
    */
   failover?: FailoverConfig;
 };

--- a/packages/livekit-server-sdk/src/ClientOptions.ts
+++ b/packages/livekit-server-sdk/src/ClientOptions.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 import type { FailoverConfig } from './failover.js';
 
 /**

--- a/packages/livekit-server-sdk/src/ClientOptions.ts
+++ b/packages/livekit-server-sdk/src/ClientOptions.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import type { FailoverConfig } from './failover.js';
+
 /**
  * Options common to all clients
  */
@@ -10,4 +12,9 @@ export type ClientOptions = {
    * Optional timeout, in seconds, for all server requests
    */
   requestTimeout?: number;
+  /**
+   * Region-failover behavior for API requests. Defaults to auto, which fails
+   * over to alternative regions for LiveKit Cloud hosts on retryable errors.
+   */
+  failover?: FailoverConfig;
 };

--- a/packages/livekit-server-sdk/src/ClientOptions.ts
+++ b/packages/livekit-server-sdk/src/ClientOptions.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { FailoverConfig } from './failover.js';
 
 /**
  * Options common to all clients
@@ -12,9 +11,8 @@ export type ClientOptions = {
    */
   requestTimeout?: number;
   /**
-   * Region-failover tuning for API requests. Omit it (the default) to enable
-   * failover for LiveKit Cloud hosts only; pass a config to enable it for any
-   * host. Set `maxAttempts: 1` to disable.
+   * Whether to fail over to alternative regions on retryable errors (LiveKit
+   * Cloud hosts only). Defaults to true; set to false to disable.
    */
-  failover?: FailoverConfig;
+  failover?: boolean;
 };

--- a/packages/livekit-server-sdk/src/ConnectorClient.ts
+++ b/packages/livekit-server-sdk/src/ConnectorClient.ts
@@ -23,6 +23,7 @@ import {
 import type { ClientOptions } from './ClientOptions.js';
 import { ServiceBase } from './ServiceBase.js';
 import { type Rpc, TwirpRpc, livekitPackage } from './TwirpRPC.js';
+import { dialRequestTimeout } from './dialTimeout.js';
 
 const svc = 'Connector';
 
@@ -87,6 +88,12 @@ export interface AcceptWhatsAppCallOptions {
   ringingTimeout?: number;
   /** Optional - Wait for the call to be answered before returning */
   waitUntilAnswered?: boolean;
+  /**
+   * Optional - Request timeout in seconds. When `waitUntilAnswered` is set,
+   * defaults to a longer value (dialing takes time) and is raised, if needed,
+   * to stay above `ringingTimeout`; otherwise the client default applies.
+   */
+  timeout?: number;
 }
 
 // Twilio types
@@ -206,11 +213,19 @@ export class ConnectorClient extends ServiceBase {
       waitUntilAnswered: options.waitUntilAnswered,
     }).toJson();
 
+    // Waiting for the call to be answered dials a phone, which takes longer than
+    // a normal request and must outlast ringing; otherwise the client default
+    // applies (unless the caller specified a timeout).
+    const timeout = options.waitUntilAnswered
+      ? dialRequestTimeout(options.timeout, options.ringingTimeout)
+      : options.timeout;
+
     const data = await this.rpc.request(
       svc,
       'AcceptWhatsAppCall',
       req,
       await this.authHeader({ roomCreate: true }),
+      timeout,
     );
     return AcceptWhatsAppCallResponse.fromJson(data, { ignoreUnknownFields: true });
   }

--- a/packages/livekit-server-sdk/src/ConnectorClient.ts
+++ b/packages/livekit-server-sdk/src/ConnectorClient.ts
@@ -123,10 +123,10 @@ export class ConnectorClient extends ServiceBase {
    */
   constructor(host: string, apiKey?: string, secret?: string, options?: ClientOptions) {
     super(apiKey, secret);
-    const rpcOptions = options?.requestTimeout
-      ? { requestTimeout: options.requestTimeout }
-      : undefined;
-    this.rpc = new TwirpRpc(host, livekitPackage, rpcOptions);
+    this.rpc = new TwirpRpc(host, livekitPackage, {
+      requestTimeout: options?.requestTimeout,
+      failover: options?.failover,
+    });
   }
 
   /**

--- a/packages/livekit-server-sdk/src/ConnectorClient.ts
+++ b/packages/livekit-server-sdk/src/ConnectorClient.ts
@@ -23,7 +23,7 @@ import {
 import type { ClientOptions } from './ClientOptions.js';
 import { ServiceBase } from './ServiceBase.js';
 import { type Rpc, TwirpRpc, livekitPackage } from './TwirpRPC.js';
-import { DEFAULT_RINGING_TIMEOUT_SECONDS, dialRequestTimeout } from './dialTimeout.js';
+import { DEFAULT_RINGING_TIMEOUT_SECONDS } from './dialTimeout.js';
 
 const svc = 'Connector';
 
@@ -193,12 +193,6 @@ export class ConnectorClient extends ServiceBase {
     const participantMetadata = options.participantMetadata || '';
     const destinationCountry = options.destinationCountry || '';
 
-    // When waiting for an answer, pin the ring window explicitly so our request
-    // timeout doesn't depend on the server's default (which could change).
-    if (options.waitUntilAnswered) {
-      options.ringingTimeout ??= DEFAULT_RINGING_TIMEOUT_SECONDS;
-    }
-
     const req = new AcceptWhatsAppCallRequest({
       whatsappPhoneNumberId: options.whatsappPhoneNumberId,
       whatsappApiKey: options.whatsappApiKey,
@@ -219,11 +213,13 @@ export class ConnectorClient extends ServiceBase {
       waitUntilAnswered: options.waitUntilAnswered,
     }).toJson();
 
-    // Waiting for the call to be answered dials a phone, which takes longer than
-    // a normal request and must outlast ringing; otherwise the client default
-    // applies (unless the caller specified a timeout).
+    // Accept can block until the call is answered, so default the request timeout
+    // to the standard ring window. The caller overrides it via `timeout` and
+    // should set it above the ringing_timeout passed to dialWhatsAppCall; the
+    // two calls are separate, so the SDK can't derive it. Non-waiting returns
+    // promptly and uses the client default.
     const timeout = options.waitUntilAnswered
-      ? dialRequestTimeout(options.timeout, options.ringingTimeout)
+      ? (options.timeout ?? DEFAULT_RINGING_TIMEOUT_SECONDS)
       : options.timeout;
 
     const data = await this.rpc.request(

--- a/packages/livekit-server-sdk/src/ConnectorClient.ts
+++ b/packages/livekit-server-sdk/src/ConnectorClient.ts
@@ -23,7 +23,7 @@ import {
 import type { ClientOptions } from './ClientOptions.js';
 import { ServiceBase } from './ServiceBase.js';
 import { type Rpc, TwirpRpc, livekitPackage } from './TwirpRPC.js';
-import { dialRequestTimeout } from './dialTimeout.js';
+import { DEFAULT_RINGING_TIMEOUT_SECONDS, dialRequestTimeout } from './dialTimeout.js';
 
 const svc = 'Connector';
 
@@ -192,6 +192,12 @@ export class ConnectorClient extends ServiceBase {
     const participantName = options.participantName || '';
     const participantMetadata = options.participantMetadata || '';
     const destinationCountry = options.destinationCountry || '';
+
+    // When waiting for an answer, pin the ring window explicitly so our request
+    // timeout doesn't depend on the server's default (which could change).
+    if (options.waitUntilAnswered) {
+      options.ringingTimeout ??= DEFAULT_RINGING_TIMEOUT_SECONDS;
+    }
 
     const req = new AcceptWhatsAppCallRequest({
       whatsappPhoneNumberId: options.whatsappPhoneNumberId,

--- a/packages/livekit-server-sdk/src/EgressClient.ts
+++ b/packages/livekit-server-sdk/src/EgressClient.ts
@@ -142,10 +142,10 @@ export class EgressClient extends ServiceBase {
    */
   constructor(host: string, apiKey?: string, secret?: string, options?: ClientOptions) {
     super(apiKey, secret);
-    const rpcOptions = options?.requestTimeout
-      ? { requestTimeout: options.requestTimeout }
-      : undefined;
-    this.rpc = new TwirpRpc(host, livekitPackage, rpcOptions);
+    this.rpc = new TwirpRpc(host, livekitPackage, {
+      requestTimeout: options?.requestTimeout,
+      failover: options?.failover,
+    });
   }
 
   /**

--- a/packages/livekit-server-sdk/src/IngressClient.ts
+++ b/packages/livekit-server-sdk/src/IngressClient.ts
@@ -129,10 +129,10 @@ export class IngressClient extends ServiceBase {
    */
   constructor(host: string, apiKey?: string, secret?: string, options?: ClientOptions) {
     super(apiKey, secret);
-    const rpcOptions = options?.requestTimeout
-      ? { requestTimeout: options.requestTimeout }
-      : undefined;
-    this.rpc = new TwirpRpc(host, livekitPackage, rpcOptions);
+    this.rpc = new TwirpRpc(host, livekitPackage, {
+      requestTimeout: options?.requestTimeout,
+      failover: options?.failover,
+    });
   }
 
   /**

--- a/packages/livekit-server-sdk/src/RoomServiceClient.ts
+++ b/packages/livekit-server-sdk/src/RoomServiceClient.ts
@@ -132,10 +132,10 @@ export class RoomServiceClient extends ServiceBase {
    */
   constructor(host: string, apiKey?: string, secret?: string, options?: ClientOptions) {
     super(apiKey, secret);
-    const rpcOptions = options?.requestTimeout
-      ? { requestTimeout: options.requestTimeout }
-      : undefined;
-    this.rpc = new TwirpRpc(host, livekitPackage, rpcOptions);
+    this.rpc = new TwirpRpc(host, livekitPackage, {
+      requestTimeout: options?.requestTimeout,
+      failover: options?.failover,
+    });
   }
 
   /**

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -48,6 +48,29 @@ import { TwirpRpc, livekitPackage } from './TwirpRPC.js';
 
 const svc = 'SIP';
 
+/** Default request timeout (seconds) for calls that dial a phone. */
+const SIP_DIAL_TIMEOUT_SECONDS = 30;
+
+/**
+ * When a call waits on ringing, the request must outlast the ringing window or
+ * it would abort before the call can be answered. We keep at least this margin
+ * (seconds) of request timeout above the ringing timeout.
+ */
+const RINGING_TIMEOUT_MARGIN_SECONDS = 2;
+
+/**
+ * Resolves the request timeout for a phone-dialing call: a user-supplied value
+ * (or the dial default) raised, when needed, to stay at least
+ * {@link RINGING_TIMEOUT_MARGIN_SECONDS} above any ringing timeout.
+ */
+function dialRequestTimeout(timeout: number | undefined, ringingTimeout: number | undefined): number {
+  let effective = timeout ?? SIP_DIAL_TIMEOUT_SECONDS;
+  if (ringingTimeout !== undefined) {
+    effective = Math.max(effective, ringingTimeout + RINGING_TIMEOUT_MARGIN_SECONDS);
+  }
+  return effective;
+}
+
 /**
  * @deprecated use CreateSipInboundTrunkOptions or CreateSipOutboundTrunkOptions
  */
@@ -223,6 +246,8 @@ export interface TransferSipParticipantOptions {
   headers?: { [key: string]: string };
   /** Maximum time for the transfer destination to answer the call, in seconds. */
   ringingTimeout?: number;
+  /** Optional request timeout in seconds. Defaults to 30s (dialing takes time). */
+  timeout?: number;
 }
 
 /**
@@ -752,9 +777,10 @@ export class SipClient extends ServiceBase {
       opts = {};
     }
 
-    // Dialing a phone and waiting for an answer takes longer than a normal call.
-    if (opts.timeout === undefined && opts.waitUntilAnswered) {
-      opts.timeout = 30;
+    // Dialing a phone and waiting for an answer takes longer than a normal call,
+    // and the request must outlast ringing so the call can be answered.
+    if (opts.waitUntilAnswered) {
+      opts.timeout = dialRequestTimeout(opts.timeout, opts.ringingTimeout);
     }
 
     const req = new CreateSIPParticipantRequest({
@@ -811,6 +837,11 @@ export class SipClient extends ServiceBase {
       opts = {};
     }
 
+    // Transferring a call dials a phone, which takes longer than a normal call,
+    // so default to a longer timeout unless the user specified one, and keep the
+    // request alive past ringing so the transfer destination can answer.
+    opts.timeout = dialRequestTimeout(opts.timeout, opts.ringingTimeout);
+
     const req = new TransferSIPParticipantRequest({
       participantIdentity: participantIdentity,
       roomName: roomName,
@@ -827,8 +858,7 @@ export class SipClient extends ServiceBase {
       'TransferSIPParticipant',
       req,
       await this.authHeader({ roomAdmin: true, room: roomName }, { call: true }),
-      // Transferring a call dials a phone, which takes longer than a normal call.
-      30,
+      opts.timeout,
     );
   }
 }

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -45,31 +45,9 @@ import type { ClientOptions } from './ClientOptions.js';
 import { ServiceBase } from './ServiceBase.js';
 import type { Rpc } from './TwirpRPC.js';
 import { TwirpRpc, livekitPackage } from './TwirpRPC.js';
+import { dialRequestTimeout } from './dialTimeout.js';
 
 const svc = 'SIP';
-
-/** Default request timeout (seconds) for calls that dial a phone. */
-const SIP_DIAL_TIMEOUT_SECONDS = 30;
-
-/**
- * When a call waits on ringing, the request must outlast the ringing window or
- * it would abort before the call can be answered. We keep at least this margin
- * (seconds) of request timeout above the ringing timeout.
- */
-const RINGING_TIMEOUT_MARGIN_SECONDS = 2;
-
-/**
- * Resolves the request timeout for a phone-dialing call: a user-supplied value
- * (or the dial default) raised, when needed, to stay at least
- * {@link RINGING_TIMEOUT_MARGIN_SECONDS} above any ringing timeout.
- */
-function dialRequestTimeout(timeout: number | undefined, ringingTimeout: number | undefined): number {
-  let effective = timeout ?? SIP_DIAL_TIMEOUT_SECONDS;
-  if (ringingTimeout !== undefined) {
-    effective = Math.max(effective, ringingTimeout + RINGING_TIMEOUT_MARGIN_SECONDS);
-  }
-  return effective;
-}
 
 /**
  * @deprecated use CreateSipInboundTrunkOptions or CreateSipOutboundTrunkOptions

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -165,7 +165,7 @@ export interface CreateSipParticipantOptions {
   krispEnabled?: boolean;
   /** If `true`, this will wait until the call is answered before returning. */
   waitUntilAnswered?: boolean;
-  /** Optional request timeout in seconds. default 60 seconds if waitUntilAnswered is true, otherwise 10 seconds */
+  /** Optional request timeout in seconds. Defaults to 30s when waitUntilAnswered is true (dialing takes time), otherwise the client default. */
   timeout?: number;
 }
 
@@ -752,8 +752,9 @@ export class SipClient extends ServiceBase {
       opts = {};
     }
 
-    if (opts.timeout === undefined) {
-      opts.timeout = opts.waitUntilAnswered ? 60 : 10;
+    // Dialing a phone and waiting for an answer takes longer than a normal call.
+    if (opts.timeout === undefined && opts.waitUntilAnswered) {
+      opts.timeout = 30;
     }
 
     const req = new CreateSIPParticipantRequest({
@@ -826,6 +827,8 @@ export class SipClient extends ServiceBase {
       'TransferSIPParticipant',
       req,
       await this.authHeader({ roomAdmin: true, room: roomName }, { call: true }),
+      // Transferring a call dials a phone, which takes longer than a normal call.
+      30,
     );
   }
 }

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -239,10 +239,10 @@ export class SipClient extends ServiceBase {
    */
   constructor(host: string, apiKey?: string, secret?: string, options?: ClientOptions) {
     super(apiKey, secret);
-    const rpcOptions = options?.requestTimeout
-      ? { requestTimeout: options.requestTimeout }
-      : undefined;
-    this.rpc = new TwirpRpc(host, livekitPackage, rpcOptions);
+    this.rpc = new TwirpRpc(host, livekitPackage, {
+      requestTimeout: options?.requestTimeout,
+      failover: options?.failover,
+    });
   }
 
   /**

--- a/packages/livekit-server-sdk/src/SipClient.ts
+++ b/packages/livekit-server-sdk/src/SipClient.ts
@@ -45,7 +45,7 @@ import type { ClientOptions } from './ClientOptions.js';
 import { ServiceBase } from './ServiceBase.js';
 import type { Rpc } from './TwirpRPC.js';
 import { TwirpRpc, livekitPackage } from './TwirpRPC.js';
-import { dialRequestTimeout } from './dialTimeout.js';
+import { DEFAULT_RINGING_TIMEOUT_SECONDS, dialRequestTimeout } from './dialTimeout.js';
 
 const svc = 'SIP';
 
@@ -756,8 +756,11 @@ export class SipClient extends ServiceBase {
     }
 
     // Dialing a phone and waiting for an answer takes longer than a normal call,
-    // and the request must outlast ringing so the call can be answered.
+    // and the request must outlast ringing so the call can be answered. Pin the
+    // ring window explicitly so our request timeout doesn't depend on the server's
+    // default (which could change out from under us).
     if (opts.waitUntilAnswered) {
+      opts.ringingTimeout ??= DEFAULT_RINGING_TIMEOUT_SECONDS;
       opts.timeout = dialRequestTimeout(opts.timeout, opts.ringingTimeout);
     }
 
@@ -816,8 +819,9 @@ export class SipClient extends ServiceBase {
     }
 
     // Transferring a call dials a phone, which takes longer than a normal call,
-    // so default to a longer timeout unless the user specified one, and keep the
-    // request alive past ringing so the transfer destination can answer.
+    // so keep the request alive past ringing. Pin the ring window explicitly so
+    // our request timeout doesn't depend on the server's default.
+    opts.ringingTimeout ??= DEFAULT_RINGING_TIMEOUT_SECONDS;
     opts.timeout = dialRequestTimeout(opts.timeout, opts.ringingTimeout);
 
     const req = new TransferSIPParticipantRequest({

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { JsonValue } from '@bufbuild/protobuf';
-import type { FailoverConfig } from './failover.js';
 import {
-  failoverBackoffBase,
-  failoverMaxAttempts,
+  FAILOVER_BACKOFF_BASE_MS,
+  failoverAttempts,
   hostKey,
   pickNext,
   regionOrigins,
@@ -19,8 +18,12 @@ type Options = {
   prefix?: string;
   /** Timeout for fetch requests, in seconds. Must be within the valid range for abort signal timeouts. */
   requestTimeout?: number;
-  /** Region-failover behavior. Defaults to auto (enabled for LiveKit Cloud hosts). */
-  failover?: FailoverConfig;
+  /** Whether region failover is enabled (LiveKit Cloud hosts only). Defaults to true. */
+  failover?: boolean;
+  /** @internal test-only: force failover regardless of host. */
+  failoverForce?: boolean;
+  /** @internal test-only: base retry backoff in ms. */
+  failoverBackoffMs?: number;
 };
 
 const defaultPrefix = '/twirp';
@@ -69,7 +72,11 @@ export class TwirpRpc {
 
   requestTimeout: number;
 
-  failover: FailoverConfig | undefined;
+  failover: boolean;
+
+  private failoverForce: boolean;
+
+  private failoverBackoffMs: number;
 
   constructor(host: string, pkg: string, options?: Options) {
     if (host.startsWith('ws')) {
@@ -79,7 +86,9 @@ export class TwirpRpc {
     this.pkg = pkg;
     this.requestTimeout = options?.requestTimeout ?? defaultTimeoutSeconds;
     this.prefix = options?.prefix || defaultPrefix;
-    this.failover = options?.failover;
+    this.failover = options?.failover ?? true;
+    this.failoverForce = options?.failoverForce ?? false;
+    this.failoverBackoffMs = options?.failoverBackoffMs ?? FAILOVER_BACKOFF_BASE_MS;
   }
 
   /**
@@ -105,7 +114,7 @@ export class TwirpRpc {
     };
 
     const origin = new URL(this.host);
-    const maxAttempts = failoverMaxAttempts(this.failover, origin.hostname);
+    const maxAttempts = failoverAttempts(this.failover, origin.hostname, this.failoverForce);
     const attempted = new Set([hostKey(origin)]);
     let regions: string[] | undefined;
     let current = this.host;
@@ -152,7 +161,11 @@ export class TwirpRpc {
         throw transportError;
       }
 
-      await sleep(failoverBackoffBase(this.failover) * 2 ** attempt);
+      const reason = response ? `status ${response.status}` : transportError;
+      console.warn(
+        `livekit API request to ${new URL(current).host} failed (${reason}), retrying with fallback url ${next}`,
+      );
+      await sleep(this.failoverBackoffMs * 2 ** attempt);
       attempted.add(hostKey(new URL(next)));
       current = next;
     }

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -27,7 +27,7 @@ type Options = {
 };
 
 const defaultPrefix = '/twirp';
-const defaultTimeoutSeconds = 60;
+const defaultTimeoutSeconds = 10;
 
 export const livekitPackage = 'livekit';
 export interface Rpc {
@@ -114,7 +114,12 @@ export class TwirpRpc {
     };
 
     const origin = new URL(this.host);
-    const maxAttempts = failoverAttempts(this.failover, origin.hostname, this.failoverForce);
+    const maxAttempts = failoverAttempts(
+      this.failover,
+      origin.hostname,
+      this.failoverForce,
+      timeout,
+    );
     const attempted = new Set([hostKey(origin)]);
     let regions: string[] | undefined;
     let current = this.host;

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -2,6 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { JsonValue } from '@bufbuild/protobuf';
+import type { FailoverConfig, ResolvedFailover } from './failover.js';
+import {
+  failoverEnabled,
+  hostKey,
+  pickNext,
+  regionOrigins,
+  resolveFailover,
+  sleep,
+} from './failover.js';
 
 // twirp RPC adapter for client implementation
 
@@ -10,6 +19,8 @@ type Options = {
   prefix?: string;
   /** Timeout for fetch requests, in seconds. Must be within the valid range for abort signal timeouts. */
   requestTimeout?: number;
+  /** Region-failover behavior. Defaults to auto (enabled for LiveKit Cloud hosts). */
+  failover?: FailoverConfig;
 };
 
 const defaultPrefix = '/twirp';
@@ -58,6 +69,8 @@ export class TwirpRpc {
 
   requestTimeout: number;
 
+  failover: ResolvedFailover;
+
   constructor(host: string, pkg: string, options?: Options) {
     if (host.startsWith('ws')) {
       host = host.replace('ws', 'http');
@@ -66,8 +79,16 @@ export class TwirpRpc {
     this.pkg = pkg;
     this.requestTimeout = options?.requestTimeout ?? defaultTimeoutSeconds;
     this.prefix = options?.prefix || defaultPrefix;
+    this.failover = resolveFailover(options?.failover);
   }
 
+  /**
+   * Issues a Twirp request, failing over to alternative regions on retryable
+   * errors. On any transport error or HTTP 5xx it discovers regions via
+   * /settings/regions and replays the request — body and headers intact —
+   * against the next untried region, with exponential backoff. A 4xx is
+   * returned immediately.
+   */
   async request(
     service: string,
     method: string,
@@ -77,52 +98,94 @@ export class TwirpRpc {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
     const path = `${this.prefix}/${this.pkg}.${service}/${method}`;
-    const url = new URL(path, this.host);
-    const init: RequestInit = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-        ...headers,
-      },
-      body: JSON.stringify(data),
+    const body = JSON.stringify(data);
+    const requestHeaders = {
+      'Content-Type': 'application/json;charset=UTF-8',
+      ...headers,
     };
 
-    if (timeout) {
-      init.signal = AbortSignal.timeout(timeout * 1000);
-    }
+    const origin = new URL(this.host);
+    const enabled = failoverEnabled(this.failover, origin.hostname);
+    const maxAttempts = enabled ? Math.max(1, this.failover.maxAttempts) : 1;
+    const attempted = new Set([hostKey(origin)]);
+    let regions: string[] | undefined;
+    let current = this.host;
 
-    const response = await fetch(url, init);
-
-    if (!response.ok) {
-      const isJson = response.headers.get('content-type') === 'application/json';
-      let errorMessage = 'Unknown internal error';
-      let errorCode: string | undefined = undefined;
-      let metadata: Record<string, string> | undefined = undefined;
-      try {
-        if (isJson) {
-          const parsedError = (await response.json()) as Record<string, unknown>;
-          if ('msg' in parsedError) {
-            errorMessage = <string>parsedError.msg;
-          }
-          if ('code' in parsedError) {
-            errorCode = <string>parsedError.code;
-          }
-          if ('meta' in parsedError) {
-            metadata = <Record<string, string>>parsedError.meta;
-          }
-        } else {
-          errorMessage = await response.text();
-        }
-      } catch (e) {
-        // parsing went wrong, no op and we keep default error message
-        console.debug(`Error when trying to parse error message, using defaults`, e);
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const isLast = attempt + 1 >= maxAttempts;
+      const init: RequestInit = { method: 'POST', headers: requestHeaders, body };
+      if (timeout) {
+        init.signal = AbortSignal.timeout(timeout * 1000);
       }
 
-      throw new TwirpError(response.statusText, errorMessage, response.status, errorCode, metadata);
-    }
-    const parsedResp = (await response.json()) as Record<string, unknown>;
+      let response: Response | undefined;
+      let transportError: unknown;
+      try {
+        response = await fetch(new URL(path, current), init);
+      } catch (e) {
+        transportError = e;
+      }
 
-    const camelcaseKeys = await import('camelcase-keys').then((mod) => mod.default);
-    return camelcaseKeys(parsedResp, { deep: true });
+      if (response?.ok) {
+        // Return the raw JSON. Every caller parses it with protobuf-es
+        // fromJson(), which per the proto3 JSON spec accepts both the proto
+        // field names (snake_case) and their json_name (camelCase), so no key
+        // conversion is needed. Converting keys would also corrupt map<string,…>
+        // entries (e.g. participant attributes), whose keys are user data.
+        return (await response.json()) as Record<string, unknown>;
+      }
+
+      // Only retryable failures (a transport error or HTTP 5xx) continue;
+      // a 4xx is terminal.
+      const retryable = transportError !== undefined || (!!response && response.status >= 500);
+      let next: string | undefined;
+      if (retryable && !isLast) {
+        if (!regions) {
+          regions = await regionOrigins(origin, headers);
+        }
+        next = pickNext(regions, attempted);
+      }
+
+      if (!retryable || next === undefined) {
+        if (response) {
+          throw await toTwirpError(response);
+        }
+        throw transportError;
+      }
+
+      await sleep(this.failover.backoffBase * 2 ** attempt);
+      attempted.add(hostKey(new URL(next)));
+      current = next;
+    }
+
+    throw new Error('failover loop exited without returning'); // unreachable
   }
+}
+
+/** Builds a TwirpError from a non-2xx response, mirroring Twirp's JSON error shape. */
+async function toTwirpError(response: Response): Promise<TwirpError> {
+  const isJson = response.headers.get('content-type') === 'application/json';
+  let errorMessage = 'Unknown internal error';
+  let errorCode: string | undefined = undefined;
+  let metadata: Record<string, string> | undefined = undefined;
+  try {
+    if (isJson) {
+      const parsedError = (await response.json()) as Record<string, unknown>;
+      if ('msg' in parsedError) {
+        errorMessage = <string>parsedError.msg;
+      }
+      if ('code' in parsedError) {
+        errorCode = <string>parsedError.code;
+      }
+      if ('meta' in parsedError) {
+        metadata = <Record<string, string>>parsedError.meta;
+      }
+    } else {
+      errorMessage = await response.text();
+    }
+  } catch (e) {
+    // parsing went wrong, no op and we keep default error message
+    console.debug(`Error when trying to parse error message, using defaults`, e);
+  }
+  return new TwirpError(response.statusText, errorMessage, response.status, errorCode, metadata);
 }

--- a/packages/livekit-server-sdk/src/TwirpRPC.ts
+++ b/packages/livekit-server-sdk/src/TwirpRPC.ts
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { JsonValue } from '@bufbuild/protobuf';
-import type { FailoverConfig, ResolvedFailover } from './failover.js';
+import type { FailoverConfig } from './failover.js';
 import {
-  failoverEnabled,
+  failoverBackoffBase,
+  failoverMaxAttempts,
   hostKey,
   pickNext,
   regionOrigins,
-  resolveFailover,
   sleep,
 } from './failover.js';
 
@@ -69,7 +69,7 @@ export class TwirpRpc {
 
   requestTimeout: number;
 
-  failover: ResolvedFailover;
+  failover: FailoverConfig | undefined;
 
   constructor(host: string, pkg: string, options?: Options) {
     if (host.startsWith('ws')) {
@@ -79,7 +79,7 @@ export class TwirpRpc {
     this.pkg = pkg;
     this.requestTimeout = options?.requestTimeout ?? defaultTimeoutSeconds;
     this.prefix = options?.prefix || defaultPrefix;
-    this.failover = resolveFailover(options?.failover);
+    this.failover = options?.failover;
   }
 
   /**
@@ -105,8 +105,7 @@ export class TwirpRpc {
     };
 
     const origin = new URL(this.host);
-    const enabled = failoverEnabled(this.failover, origin.hostname);
-    const maxAttempts = enabled ? Math.max(1, this.failover.maxAttempts) : 1;
+    const maxAttempts = failoverMaxAttempts(this.failover, origin.hostname);
     const attempted = new Set([hostKey(origin)]);
     let regions: string[] | undefined;
     let current = this.host;
@@ -153,7 +152,7 @@ export class TwirpRpc {
         throw transportError;
       }
 
-      await sleep(this.failover.backoffBase * 2 ** attempt);
+      await sleep(failoverBackoffBase(this.failover) * 2 ** attempt);
       attempted.add(hostKey(new URL(next)));
       current = next;
     }

--- a/packages/livekit-server-sdk/src/dialTimeout.test.ts
+++ b/packages/livekit-server-sdk/src/dialTimeout.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import {
+  DIAL_TIMEOUT_SECONDS,
+  RINGING_TIMEOUT_MARGIN_SECONDS,
+  dialRequestTimeout,
+} from './dialTimeout.js';
+
+describe('dialRequestTimeout', () => {
+  it('defaults to the dial timeout when nothing is specified', () => {
+    expect(dialRequestTimeout(undefined, undefined)).toBe(DIAL_TIMEOUT_SECONDS);
+  });
+
+  it('honors a user-supplied timeout when there is no ringing timeout', () => {
+    expect(dialRequestTimeout(45, undefined)).toBe(45);
+    expect(dialRequestTimeout(5, undefined)).toBe(5);
+  });
+
+  it('keeps the dial default above a short ringing timeout', () => {
+    // ringing + margin (12) is below the 30s default, so the default wins.
+    expect(dialRequestTimeout(undefined, 10)).toBe(DIAL_TIMEOUT_SECONDS);
+  });
+
+  it('raises the timeout to stay above a long ringing timeout', () => {
+    expect(dialRequestTimeout(undefined, 60)).toBe(60 + RINGING_TIMEOUT_MARGIN_SECONDS);
+  });
+
+  it('raises a user timeout that is too tight for the ringing window', () => {
+    // user asked for 30s but ringing is 40s; must outlast ringing by the margin.
+    expect(dialRequestTimeout(30, 40)).toBe(40 + RINGING_TIMEOUT_MARGIN_SECONDS);
+  });
+
+  it('keeps a user timeout that already clears the ringing window', () => {
+    expect(dialRequestTimeout(90, 40)).toBe(90);
+  });
+});

--- a/packages/livekit-server-sdk/src/dialTimeout.test.ts
+++ b/packages/livekit-server-sdk/src/dialTimeout.test.ts
@@ -3,24 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import {
-  DIAL_TIMEOUT_SECONDS,
+  DEFAULT_RINGING_TIMEOUT_SECONDS,
   RINGING_TIMEOUT_MARGIN_SECONDS,
   dialRequestTimeout,
 } from './dialTimeout.js';
 
+const DEFAULT_FLOOR = DEFAULT_RINGING_TIMEOUT_SECONDS + RINGING_TIMEOUT_MARGIN_SECONDS;
+
 describe('dialRequestTimeout', () => {
-  it('defaults to the dial timeout when nothing is specified', () => {
-    expect(dialRequestTimeout(undefined, undefined)).toBe(DIAL_TIMEOUT_SECONDS);
+  it('falls back to the default ring window plus margin when nothing is set', () => {
+    // No ringing timeout means the server's default ring applies, so the request
+    // must still outlast it by the margin.
+    expect(dialRequestTimeout(undefined, undefined)).toBe(DEFAULT_FLOOR);
   });
 
-  it('honors a user-supplied timeout when there is no ringing timeout', () => {
+  it('honors a user timeout above the default floor, raises one below it', () => {
     expect(dialRequestTimeout(45, undefined)).toBe(45);
-    expect(dialRequestTimeout(5, undefined)).toBe(5);
+    expect(dialRequestTimeout(5, undefined)).toBe(DEFAULT_FLOOR);
   });
 
-  it('keeps the dial default above a short ringing timeout', () => {
-    // ringing + margin (12) is below the 30s default, so the default wins.
-    expect(dialRequestTimeout(undefined, 10)).toBe(DIAL_TIMEOUT_SECONDS);
+  it('tracks a short ringing timeout (ring + margin), no fixed floor', () => {
+    expect(dialRequestTimeout(undefined, 10)).toBe(10 + RINGING_TIMEOUT_MARGIN_SECONDS);
   });
 
   it('raises the timeout to stay above a long ringing timeout', () => {

--- a/packages/livekit-server-sdk/src/dialTimeout.ts
+++ b/packages/livekit-server-sdk/src/dialTimeout.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared request-timeout handling for calls that dial a phone and wait for an
+// answer (SIP CreateSIPParticipant/TransferSIPParticipant, WhatsApp
+// AcceptWhatsAppCall). These take longer than a normal API call, and the
+// request must outlast ringing or it would abort before the call is answered.
+
+/** Default request timeout (seconds) for calls that dial a phone. */
+export const DIAL_TIMEOUT_SECONDS = 30;
+
+/**
+ * When a call waits on ringing, the request must outlast the ringing window or
+ * it would abort before the call can be answered. We keep at least this margin
+ * (seconds) of request timeout above the ringing timeout.
+ */
+export const RINGING_TIMEOUT_MARGIN_SECONDS = 2;
+
+/**
+ * Resolves the request timeout for a phone-dialing call: a user-supplied value
+ * (or the dial default) raised, when needed, to stay at least
+ * {@link RINGING_TIMEOUT_MARGIN_SECONDS} above any ringing timeout.
+ */
+export function dialRequestTimeout(
+  timeout: number | undefined,
+  ringingTimeout: number | undefined,
+): number {
+  let effective = timeout ?? DIAL_TIMEOUT_SECONDS;
+  if (ringingTimeout !== undefined) {
+    effective = Math.max(effective, ringingTimeout + RINGING_TIMEOUT_MARGIN_SECONDS);
+  }
+  return effective;
+}

--- a/packages/livekit-server-sdk/src/dialTimeout.ts
+++ b/packages/livekit-server-sdk/src/dialTimeout.ts
@@ -7,8 +7,11 @@
 // AcceptWhatsAppCall). These take longer than a normal API call, and the
 // request must outlast ringing or it would abort before the call is answered.
 
-/** Default request timeout (seconds) for calls that dial a phone. */
-export const DIAL_TIMEOUT_SECONDS = 30;
+/**
+ * Ring window (seconds) assumed when a request doesn't set a ringing timeout;
+ * matches the server default. A dialing request must outlast it.
+ */
+export const DEFAULT_RINGING_TIMEOUT_SECONDS = 30;
 
 /**
  * When a call waits on ringing, the request must outlast the ringing window or
@@ -18,17 +21,17 @@ export const DIAL_TIMEOUT_SECONDS = 30;
 export const RINGING_TIMEOUT_MARGIN_SECONDS = 2;
 
 /**
- * Resolves the request timeout for a phone-dialing call: a user-supplied value
- * (or the dial default) raised, when needed, to stay at least
- * {@link RINGING_TIMEOUT_MARGIN_SECONDS} above any ringing timeout.
+ * Resolves the request timeout (seconds) for a phone-dialing call: the ring
+ * window plus a margin, so the request doesn't abort before the call can be
+ * answered. The ring window is the request's `ringingTimeout` when set, else
+ * {@link DEFAULT_RINGING_TIMEOUT_SECONDS}. A longer user-supplied `timeout` is
+ * honored; a shorter one is raised to the floor.
  */
 export function dialRequestTimeout(
   timeout: number | undefined,
   ringingTimeout: number | undefined,
 ): number {
-  let effective = timeout ?? DIAL_TIMEOUT_SECONDS;
-  if (ringingTimeout !== undefined) {
-    effective = Math.max(effective, ringingTimeout + RINGING_TIMEOUT_MARGIN_SECONDS);
-  }
-  return effective;
+  const ring = ringingTimeout ?? DEFAULT_RINGING_TIMEOUT_SECONDS;
+  const floor = ring + RINGING_TIMEOUT_MARGIN_SECONDS;
+  return Math.max(timeout ?? floor, floor);
 }

--- a/packages/livekit-server-sdk/src/failover.test.ts
+++ b/packages/livekit-server-sdk/src/failover.test.ts
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FAILOVER_MAX_ATTEMPTS,
+  MIN_FAILOVER_TIMEOUT_SECONDS,
+  failoverAttempts,
+  hostKey,
+  parseMaxAge,
+  pickNext,
+  regionOrigins,
+  sleep,
+} from './failover.js';
+
+describe('failoverAttempts', () => {
+  it('fails over for LiveKit Cloud hosts when enabled', () => {
+    expect(failoverAttempts(true, 'myproject.livekit.cloud')).toBe(FAILOVER_MAX_ATTEMPTS);
+    expect(failoverAttempts(true, 'myproject.region.livekit.cloud')).toBe(FAILOVER_MAX_ATTEMPTS);
+  });
+
+  it('does not fail over for non-cloud hosts', () => {
+    expect(failoverAttempts(true, 'myproject.livekit.io')).toBe(1);
+    expect(failoverAttempts(true, 'example.com')).toBe(1);
+    expect(failoverAttempts(true, '127.0.0.1')).toBe(1);
+    expect(failoverAttempts(true, 'notlivekit.cloud')).toBe(1);
+  });
+
+  it('force bypasses the cloud-host check; disabled never fails over', () => {
+    expect(failoverAttempts(true, '127.0.0.1', true)).toBe(FAILOVER_MAX_ATTEMPTS);
+    expect(failoverAttempts(false, 'myproject.livekit.cloud', true)).toBe(1);
+    expect(failoverAttempts(false, 'myproject.livekit.cloud')).toBe(1);
+  });
+
+  it('applies the thundering-herd guard for sub-threshold timeouts', () => {
+    expect(
+      failoverAttempts(true, 'myproject.livekit.cloud', false, MIN_FAILOVER_TIMEOUT_SECONDS - 1),
+    ).toBe(1);
+    expect(
+      failoverAttempts(true, 'myproject.livekit.cloud', false, MIN_FAILOVER_TIMEOUT_SECONDS),
+    ).toBe(FAILOVER_MAX_ATTEMPTS);
+    // 0 means "no timeout set" and is not guarded.
+    expect(failoverAttempts(true, 'myproject.livekit.cloud', false, 0)).toBe(FAILOVER_MAX_ATTEMPTS);
+  });
+});
+
+describe('hostKey', () => {
+  it('lowercases the host and keeps a non-default port', () => {
+    expect(hostKey(new URL('https://Example.LiveKit.Cloud/twirp'))).toBe('example.livekit.cloud');
+    expect(hostKey(new URL('https://example.livekit.cloud:8080/twirp'))).toBe(
+      'example.livekit.cloud:8080',
+    );
+  });
+});
+
+describe('pickNext', () => {
+  const origins = ['https://a.livekit.cloud', 'https://b.livekit.cloud'];
+
+  it('returns the first origin not yet attempted', () => {
+    expect(pickNext(origins, new Set())).toBe('https://a.livekit.cloud');
+    expect(pickNext(origins, new Set(['a.livekit.cloud']))).toBe('https://b.livekit.cloud');
+  });
+
+  it('returns undefined once every origin has been attempted', () => {
+    expect(pickNext(origins, new Set(['a.livekit.cloud', 'b.livekit.cloud']))).toBeUndefined();
+  });
+
+  it('skips malformed origin URLs', () => {
+    expect(pickNext(['not a url', 'https://c.livekit.cloud'], new Set())).toBe(
+      'https://c.livekit.cloud',
+    );
+  });
+});
+
+describe('sleep', () => {
+  it('resolves immediately for non-positive durations', async () => {
+    await expect(sleep(0)).resolves.toBeUndefined();
+    await expect(sleep(-5)).resolves.toBeUndefined();
+  });
+});
+
+describe('parseMaxAge', () => {
+  it('returns 0 when the header is absent or empty', () => {
+    expect(parseMaxAge(null)).toBe(0);
+    expect(parseMaxAge('')).toBe(0);
+  });
+
+  it('parses max-age (in seconds) to milliseconds', () => {
+    expect(parseMaxAge('max-age=300')).toBe(300_000);
+  });
+
+  it('finds max-age alongside other directives', () => {
+    expect(parseMaxAge('public, max-age=3600')).toBe(3_600_000);
+    expect(parseMaxAge('private, max-age=600, must-revalidate')).toBe(600_000);
+    expect(parseMaxAge('no-cache, max-age=30')).toBe(30_000);
+  });
+
+  it('is case-insensitive and tolerates surrounding whitespace', () => {
+    expect(parseMaxAge('Max-Age=300')).toBe(300_000);
+    expect(parseMaxAge('  max-age = 300 ')).toBe(0); // spaces around "=" are not valid per RFC
+    expect(parseMaxAge('public,   max-age=120')).toBe(120_000);
+  });
+
+  it('treats max-age=0 and non-caching directives as "do not cache"', () => {
+    expect(parseMaxAge('max-age=0')).toBe(0);
+    expect(parseMaxAge('no-cache')).toBe(0);
+    expect(parseMaxAge('no-store')).toBe(0);
+    expect(parseMaxAge('public')).toBe(0);
+  });
+
+  it('ignores s-maxage and only honors max-age', () => {
+    expect(parseMaxAge('s-maxage=3600, max-age=120')).toBe(120_000);
+    expect(parseMaxAge('s-maxage=3600')).toBe(0);
+  });
+
+  it('returns 0 for negative or non-numeric max-age', () => {
+    expect(parseMaxAge('max-age=-5')).toBe(0);
+    expect(parseMaxAge('max-age=abc')).toBe(0);
+  });
+});
+
+describe('regionOrigins', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockResponse = (regions: Array<{ url: string }>, cacheControl: string | null): Response =>
+    ({
+      ok: true,
+      status: 200,
+      headers: { get: (h: string) => (h.toLowerCase() === 'cache-control' ? cacheControl : null) },
+      json: async () => ({ regions }),
+    }) as unknown as Response;
+
+  it('coalesces concurrent discovery fetches for the same origin', async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => new Promise<Response>((resolve) => (resolveFetch = resolve)));
+
+    const origin = new URL('https://primary.coalesce.livekit.cloud');
+    const p1 = regionOrigins(origin, {});
+    const p2 = regionOrigins(origin, {});
+
+    // Both callers share a single in-flight request.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    resolveFetch(mockResponse([{ url: 'wss://r1.coalesce.livekit.cloud' }], 'max-age=300'));
+    const [o1, o2] = await Promise.all([p1, p2]);
+
+    expect(o1).toEqual(['https://r1.coalesce.livekit.cloud']);
+    expect(o2).toEqual(o1);
+  });
+
+  it('serves later callers from the cache within the TTL', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(mockResponse([{ url: 'wss://r.cached.livekit.cloud' }], 'max-age=300'));
+
+    const origin = new URL('https://primary.cached.livekit.cloud');
+    const first = await regionOrigins(origin, {});
+    const second = await regionOrigins(origin, {});
+
+    expect(first).toEqual(['https://r.cached.livekit.cloud']);
+    expect(second).toEqual(first);
+    // The second call is served from the cache, so no second fetch.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache when the TTL is zero (max-age=0)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(mockResponse([{ url: 'wss://r.nocache.livekit.cloud' }], 'max-age=0'));
+
+    const origin = new URL('https://primary.nocache.livekit.cloud');
+    await regionOrigins(origin, {});
+    await regionOrigins(origin, {});
+
+    // Nothing cached, so each call re-fetches.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an empty list when discovery fails and nothing is cached', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+    const origin = new URL('https://primary.error.livekit.cloud');
+    await expect(regionOrigins(origin, {})).resolves.toEqual([]);
+  });
+});

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -33,10 +33,7 @@ const DEFAULT_BACKOFF_BASE = 200;
  * config (`undefined`) failover is enabled only for LiveKit Cloud hosts; an
  * explicit config enables it for any host (`maxAttempts: 1` disables it).
  */
-export function failoverMaxAttempts(
-  config: FailoverConfig | undefined,
-  hostname: string,
-): number {
+export function failoverMaxAttempts(config: FailoverConfig | undefined, hostname: string): number {
   if (config === undefined) {
     return isCloud(hostname) ? DEFAULT_MAX_ATTEMPTS : 1;
   }

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -9,47 +9,45 @@
 // request against the next region, with exponential backoff. 4xx responses are
 // returned immediately.
 
-/** Controls when API requests fail over to alternative regions. */
-export type FailoverMode =
-  /** Fail over only for LiveKit Cloud hosts. The default. */
-  | 'auto'
-  /** Always fail over, regardless of host (primarily for tests). */
-  | 'on'
-  /** Never fail over. */
-  | 'off';
-
-/** Tunes the region-failover retry loop. */
+/**
+ * Region-failover tuning, passed as the `failover` option. Omit it (default) to
+ * enable failover for LiveKit Cloud hosts only; pass a config to enable it for
+ * any host.
+ */
 export type FailoverConfig = {
-  /** Defaults to 'auto'. */
-  mode?: FailoverMode;
-  /** Total attempts including the first — the original host plus `maxAttempts - 1` fallback regions. Defaults to 3. */
+  /**
+   * Total number of attempts including the initial request — the original host
+   * plus up to `maxAttempts - 1` fallback regions. Defaults to 3. Set to 1 to
+   * disable failover (a single attempt).
+   */
   maxAttempts?: number;
   /** Milliseconds before the first retry; each subsequent retry doubles it. Defaults to 200. */
   backoffBase?: number;
 };
 
-export type ResolvedFailover = Required<FailoverConfig>;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_BASE = 200;
 
-export function resolveFailover(config?: FailoverConfig): ResolvedFailover {
-  return {
-    mode: config?.mode ?? 'auto',
-    maxAttempts: config?.maxAttempts ?? 3,
-    backoffBase: config?.backoffBase ?? 200,
-  };
-}
-
-export function failoverEnabled(config: ResolvedFailover, hostname: string): boolean {
-  switch (config.mode) {
-    case 'off':
-      return false;
-    case 'on':
-      return true;
-    default:
-      return isCloud(hostname);
+/**
+ * Total request attempts including the initial one; 1 means no failover. With no
+ * config (`undefined`) failover is enabled only for LiveKit Cloud hosts; an
+ * explicit config enables it for any host (`maxAttempts: 1` disables it).
+ */
+export function failoverMaxAttempts(
+  config: FailoverConfig | undefined,
+  hostname: string,
+): number {
+  if (config === undefined) {
+    return isCloud(hostname) ? DEFAULT_MAX_ATTEMPTS : 1;
   }
+  return Math.max(1, config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
 }
 
-// Auto mode only enables failover for LiveKit Cloud project domains.
+export function failoverBackoffBase(config: FailoverConfig | undefined): number {
+  return config?.backoffBase ?? DEFAULT_BACKOFF_BASE;
+}
+
+// The default (no config) only enables failover for LiveKit Cloud project domains.
 function isCloud(hostname: string): boolean {
   return hostname.endsWith('.livekit.cloud');
 }

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Region failover for the Twirp API clients.
+//
+// On a retryable failure (any transport error or HTTP 5xx) the client discovers
+// alternative LiveKit Cloud regions via /settings/regions and replays the
+// request against the next region, with exponential backoff. 4xx responses are
+// returned immediately.
+
+/** Controls when API requests fail over to alternative regions. */
+export type FailoverMode =
+  /** Fail over only for LiveKit Cloud hosts. The default. */
+  | 'auto'
+  /** Always fail over, regardless of host (primarily for tests). */
+  | 'on'
+  /** Never fail over. */
+  | 'off';
+
+/** Tunes the region-failover retry loop. */
+export type FailoverConfig = {
+  /** Defaults to 'auto'. */
+  mode?: FailoverMode;
+  /** Total attempts including the first — the original host plus `maxAttempts - 1` fallback regions. Defaults to 3. */
+  maxAttempts?: number;
+  /** Milliseconds before the first retry; each subsequent retry doubles it. Defaults to 200. */
+  backoffBase?: number;
+};
+
+export type ResolvedFailover = Required<FailoverConfig>;
+
+export function resolveFailover(config?: FailoverConfig): ResolvedFailover {
+  return {
+    mode: config?.mode ?? 'auto',
+    maxAttempts: config?.maxAttempts ?? 3,
+    backoffBase: config?.backoffBase ?? 200,
+  };
+}
+
+export function failoverEnabled(config: ResolvedFailover, hostname: string): boolean {
+  switch (config.mode) {
+    case 'off':
+      return false;
+    case 'on':
+      return true;
+    default:
+      return isCloud(hostname);
+  }
+}
+
+// Auto mode only enables failover for LiveKit Cloud project domains.
+function isCloud(hostname: string): boolean {
+  return hostname.endsWith('.livekit.cloud');
+}
+
+/** Normalizes a region URL to an http(s) scheme (ws -> http, wss -> https). */
+function toHttp(url: string): string {
+  return url.startsWith('ws') ? `http${url.slice(2)}` : url;
+}
+
+/** A stable key identifying a host (including port) for dedup across attempts. */
+export function hostKey(url: URL): string {
+  return url.host.toLowerCase();
+}
+
+/** Returns the first region origin whose host has not yet been attempted. */
+export function pickNext(regionOrigins: string[], attempted: Set<string>): string | undefined {
+  for (const origin of regionOrigins) {
+    try {
+      if (!attempted.has(hostKey(new URL(origin)))) {
+        return origin;
+      }
+    } catch {
+      // skip malformed URLs
+    }
+  }
+  return undefined;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+type CacheEntry = {
+  origins: string[];
+  fetchedAt: number;
+  ttl: number; // ms
+};
+
+// Shared across all clients in the process so the region list is fetched once.
+const regionCache = new Map<string, CacheEntry>();
+
+/**
+ * Returns alternative region origins for `origin`, fetching /settings/regions
+ * if the cache is stale. Best-effort: on a fetch failure it serves a stale
+ * cached list when available, otherwise an empty list. Forwards `headers` so a
+ * valid token — and any test directives — reach the discovery endpoint.
+ */
+export async function regionOrigins(origin: URL, headers: unknown): Promise<string[]> {
+  const key = hostKey(origin);
+  const cached = regionCache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < cached.ttl) {
+    return cached.origins;
+  }
+
+  try {
+    const { origins, ttl } = await fetchRegions(origin, headers);
+    // A zero TTL (e.g. Cache-Control: max-age=0) means "do not cache".
+    if (ttl > 0) {
+      regionCache.set(key, { origins, fetchedAt: Date.now(), ttl });
+    }
+    return origins;
+  } catch {
+    return cached?.origins ?? [];
+  }
+}
+
+async function fetchRegions(
+  origin: URL,
+  headers: unknown,
+): Promise<{ origins: string[]; ttl: number }> {
+  // Forward the caller's headers (auth + any custom), minus body-specific ones.
+  const fetchHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries((headers as Record<string, string>) ?? {})) {
+    if (k.toLowerCase() === 'content-type' || k.toLowerCase() === 'content-length') continue;
+    fetchHeaders[k] = v;
+  }
+
+  const response = await fetch(new URL('/settings/regions', origin.origin), {
+    method: 'GET',
+    headers: fetchHeaders,
+  });
+  if (!response.ok) {
+    throw new Error(`region discovery failed: ${response.status}`);
+  }
+  const ttl = parseMaxAge(response.headers.get('cache-control'));
+  const body = (await response.json()) as { regions?: Array<{ url?: string }> };
+  const origins = (body.regions ?? [])
+    .filter((r) => !!r.url)
+    .map((r) => new URL(toHttp(r.url!)).origin);
+  return { origins, ttl };
+}
+
+function parseMaxAge(cacheControl: string | null): number {
+  if (!cacheControl) return 0;
+  for (const directive of cacheControl.split(',')) {
+    const trimmed = directive.trim().toLowerCase();
+    if (trimmed.startsWith('max-age=')) {
+      const secs = parseInt(trimmed.slice('max-age='.length), 10);
+      return Number.isFinite(secs) && secs > 0 ? secs * 1000 : 0;
+    }
+  }
+  return 0;
+}

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -80,6 +80,11 @@ type CacheEntry = {
 
 // Shared across all clients in the process so the region list is fetched once.
 const regionCache = new Map<string, CacheEntry>();
+// Coalesces concurrent discovery fetches per origin: while one /settings/regions
+// request is in flight, other callers for the same origin await its result
+// rather than issuing their own (avoids a thundering herd when many requests
+// fail over at once).
+const inflight = new Map<string, Promise<string[]>>();
 
 /**
  * Returns alternative region origins for `origin`, fetching /settings/regions
@@ -94,16 +99,27 @@ export async function regionOrigins(origin: URL, headers: unknown): Promise<stri
     return cached.origins;
   }
 
-  try {
-    const { origins, ttl } = await fetchRegions(origin, headers);
-    // A zero TTL (e.g. Cache-Control: max-age=0) means "do not cache".
-    if (ttl > 0) {
-      regionCache.set(key, { origins, fetchedAt: Date.now(), ttl });
-    }
-    return origins;
-  } catch {
-    return cached?.origins ?? [];
+  const existing = inflight.get(key);
+  if (existing) {
+    return existing;
   }
+  const request = (async () => {
+    try {
+      const { origins, ttl } = await fetchRegions(origin, headers);
+      // A zero TTL (e.g. Cache-Control: max-age=0) means "do not cache".
+      if (ttl > 0) {
+        regionCache.set(key, { origins, fetchedAt: Date.now(), ttl });
+      }
+      return origins;
+    } catch {
+      return cached?.origins ?? [];
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, request);
+  return request;
 }
 
 async function fetchRegions(
@@ -135,7 +151,13 @@ async function fetchRegions(
   return { origins, ttl };
 }
 
-function parseMaxAge(cacheControl: string | null): number {
+/**
+ * Returns the `max-age` from a Cache-Control header in milliseconds, or 0 when
+ * absent, non-positive, or unparseable (meaning "do not cache"). Only `max-age`
+ * is honored; other directives (including `s-maxage`, which targets shared
+ * proxies) are ignored.
+ */
+export function parseMaxAge(cacheControl: string | null): number {
   if (!cacheControl) return 0;
   for (const directive of cacheControl.split(',')) {
     const trimmed = directive.trim().toLowerCase();

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -14,17 +14,29 @@
 // that could overwhelm the server.
 export const FAILOVER_MAX_ATTEMPTS = 3;
 export const FAILOVER_BACKOFF_BASE_MS = 200;
+// Below this per-request timeout, a retry is unlikely to help and many clients
+// would retry in lockstep across regions, so a short request gets a single
+// attempt (thundering-herd guard).
+export const MIN_FAILOVER_TIMEOUT_SECONDS = 5;
 
 /**
  * Total request attempts for a host; 1 means no failover. Failover only engages
- * when enabled and the host is a LiveKit Cloud domain. `force` bypasses the
- * cloud-host check and is for internal testing only.
+ * when enabled, the host is a LiveKit Cloud domain, and the request timeout is
+ * long enough to retry. `force` bypasses the cloud-host check (test-only).
  */
-export function failoverAttempts(enabled: boolean, hostname: string, force = false): number {
-  if (enabled && (force || isCloud(hostname))) {
-    return FAILOVER_MAX_ATTEMPTS;
+export function failoverAttempts(
+  enabled: boolean,
+  hostname: string,
+  force = false,
+  timeoutSeconds = 0,
+): number {
+  if (!enabled || !(force || isCloud(hostname))) {
+    return 1;
   }
-  return 1;
+  if (timeoutSeconds > 0 && timeoutSeconds < MIN_FAILOVER_TIMEOUT_SECONDS) {
+    return 1;
+  }
+  return FAILOVER_MAX_ATTEMPTS;
 }
 
 // Failover only engages for LiveKit Cloud project domains.

--- a/packages/livekit-server-sdk/src/failover.ts
+++ b/packages/livekit-server-sdk/src/failover.ts
@@ -9,42 +9,25 @@
 // request against the next region, with exponential backoff. 4xx responses are
 // returned immediately.
 
-/**
- * Region-failover tuning, passed as the `failover` option. Omit it (default) to
- * enable failover for LiveKit Cloud hosts only; pass a config to enable it for
- * any host.
- */
-export type FailoverConfig = {
-  /**
-   * Total number of attempts including the initial request — the original host
-   * plus up to `maxAttempts - 1` fallback regions. Defaults to 3. Set to 1 to
-   * disable failover (a single attempt).
-   */
-  maxAttempts?: number;
-  /** Milliseconds before the first retry; each subsequent retry doubles it. Defaults to 200. */
-  backoffBase?: number;
-};
-
-const DEFAULT_MAX_ATTEMPTS = 3;
-const DEFAULT_BACKOFF_BASE = 200;
+// Total attempts (the original request + fallback regions) and the base retry
+// backoff are fixed, not user-configurable, so retries can't be tuned to values
+// that could overwhelm the server.
+export const FAILOVER_MAX_ATTEMPTS = 3;
+export const FAILOVER_BACKOFF_BASE_MS = 200;
 
 /**
- * Total request attempts including the initial one; 1 means no failover. With no
- * config (`undefined`) failover is enabled only for LiveKit Cloud hosts; an
- * explicit config enables it for any host (`maxAttempts: 1` disables it).
+ * Total request attempts for a host; 1 means no failover. Failover only engages
+ * when enabled and the host is a LiveKit Cloud domain. `force` bypasses the
+ * cloud-host check and is for internal testing only.
  */
-export function failoverMaxAttempts(config: FailoverConfig | undefined, hostname: string): number {
-  if (config === undefined) {
-    return isCloud(hostname) ? DEFAULT_MAX_ATTEMPTS : 1;
+export function failoverAttempts(enabled: boolean, hostname: string, force = false): number {
+  if (enabled && (force || isCloud(hostname))) {
+    return FAILOVER_MAX_ATTEMPTS;
   }
-  return Math.max(1, config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  return 1;
 }
 
-export function failoverBackoffBase(config: FailoverConfig | undefined): number {
-  return config?.backoffBase ?? DEFAULT_BACKOFF_BASE;
-}
-
-// The default (no config) only enables failover for LiveKit Cloud project domains.
+// Failover only engages for LiveKit Cloud project domains.
 function isCloud(hostname: string): boolean {
   return hostname.endsWith('.livekit.cloud');
 }
@@ -125,6 +108,9 @@ async function fetchRegions(
   const response = await fetch(new URL('/settings/regions', origin.origin), {
     method: 'GET',
     headers: fetchHeaders,
+    // Short timeout so a slow/unreachable discovery endpoint doesn't stall the
+    // failover path.
+    signal: AbortSignal.timeout(2000),
   });
   if (!response.ok) {
     throw new Error(`region discovery failed: ${response.status}`);

--- a/packages/livekit-server-sdk/src/index.ts
+++ b/packages/livekit-server-sdk/src/index.ts
@@ -81,4 +81,6 @@ export * from './IngressClient.js';
 export * from './RoomServiceClient.js';
 export * from './SipClient.js';
 export { TwirpError } from './TwirpRPC.js';
+export type { ClientOptions } from './ClientOptions.js';
+export type { FailoverConfig, FailoverMode } from './failover.js';
 export * from './WebhookReceiver.js';

--- a/packages/livekit-server-sdk/src/index.ts
+++ b/packages/livekit-server-sdk/src/index.ts
@@ -82,5 +82,5 @@ export * from './RoomServiceClient.js';
 export * from './SipClient.js';
 export { TwirpError } from './TwirpRPC.js';
 export type { ClientOptions } from './ClientOptions.js';
-export type { FailoverConfig, FailoverMode } from './failover.js';
+export type { FailoverConfig } from './failover.js';
 export * from './WebhookReceiver.js';

--- a/packages/livekit-server-sdk/src/index.ts
+++ b/packages/livekit-server-sdk/src/index.ts
@@ -82,5 +82,4 @@ export * from './RoomServiceClient.js';
 export * from './SipClient.js';
 export { TwirpError } from './TwirpRPC.js';
 export type { ClientOptions } from './ClientOptions.js';
-export type { FailoverConfig } from './failover.js';
 export * from './WebhookReceiver.js';

--- a/packages/livekit-server-sdk/test/api/failover.test.ts
+++ b/packages/livekit-server-sdk/test/api/failover.test.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// API tests against the shared mock LiveKit API server (livekit/livekit
+// cmd/test-server). Point them at a running instance with LK_TEST_SERVER_URL
+// (default http://127.0.0.1:9999); they skip when no server is reachable. In CI
+// the server is booted as a Docker container.
+//
+// See cmd/test-server/README.md for the X-Lk-Mock-* control protocol. These
+// tests drive TwirpRpc.request() directly because the public service methods do
+// not expose per-call headers.
+import { describe, expect, it } from 'vitest';
+import type { FailoverConfig } from '../../src/failover.js';
+import { TwirpError, TwirpRpc, livekitPackage } from '../../src/TwirpRPC.js';
+
+const BASE = process.env.LK_TEST_SERVER_URL ?? 'http://127.0.0.1:9999';
+
+let reachable = false;
+try {
+  reachable = (await fetch(`${BASE}/settings/regions`)).ok;
+} catch {
+  reachable = false;
+}
+
+const cfg = (mode: FailoverConfig['mode'] = 'on'): FailoverConfig => ({
+  mode,
+  maxAttempts: 3,
+  backoffBase: 1,
+});
+
+const call = (directives: Record<string, string>, mode: FailoverConfig['mode'] = 'on') => {
+  const rpc = new TwirpRpc(BASE, livekitPackage, { failover: cfg(mode) });
+  return rpc.request('RoomService', 'CreateRoom', {}, {
+    authorization: 'Bearer test-token',
+    ...directives,
+  });
+};
+
+(reachable ? describe : describe.skip)('region failover', () => {
+  it('succeeds on the primary when healthy', async () => {
+    await expect(call({})).resolves.toBeDefined();
+  });
+
+  it('fails over to a healthy region when the primary is down', async () => {
+    await expect(call({ 'x-lk-mock-fail-regions': '0' })).resolves.toBeDefined();
+  });
+
+  it('fails over to region 2 on the third attempt', async () => {
+    await expect(call({ 'x-lk-mock-fail-regions': '0,1' })).resolves.toBeDefined();
+  });
+
+  it('surfaces an error when all regions are down', async () => {
+    await expect(call({ 'x-lk-mock-fail-regions': '0,1,2,3' })).rejects.toThrow(TwirpError);
+  });
+
+  it('does not retry a 4xx', async () => {
+    await expect(
+      call({ 'x-lk-mock-fail-regions': '0', 'x-lk-mock-fail-status': '400' }),
+    ).rejects.toMatchObject({ code: 'invalid_argument' });
+  });
+
+  it('fails over on a transport error', async () => {
+    await expect(
+      call({ 'x-lk-mock-fail-regions': '0', 'x-lk-mock-fail-mode': 'drop' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('surfaces the original error when region discovery is unreachable', async () => {
+    await expect(
+      call({ 'x-lk-mock-fail-regions': '0', 'x-lk-mock-regions-status': '500' }),
+    ).rejects.toThrow(TwirpError);
+  });
+
+  it('does not fail over for a non-cloud host in auto mode', async () => {
+    await expect(call({ 'x-lk-mock-fail-regions': '0' }, 'auto')).rejects.toThrow(TwirpError);
+  });
+});

--- a/packages/livekit-server-sdk/test/api/failover.test.ts
+++ b/packages/livekit-server-sdk/test/api/failover.test.ts
@@ -23,14 +23,15 @@ try {
   reachable = false;
 }
 
-const cfg = (mode: FailoverConfig['mode'] = 'on'): FailoverConfig => ({
-  mode,
-  maxAttempts: 3,
-  backoffBase: 1,
-});
+// An explicit config enables failover on any host (the non-cloud mock) with a
+// tiny backoff so the tests run fast.
+const FORCED: FailoverConfig = { maxAttempts: 3, backoffBase: 1 };
 
-const call = (directives: Record<string, string>, mode: FailoverConfig['mode'] = 'on') => {
-  const rpc = new TwirpRpc(BASE, livekitPackage, { failover: cfg(mode) });
+const call = (
+  directives: Record<string, string>,
+  failover: FailoverConfig | undefined = FORCED,
+) => {
+  const rpc = new TwirpRpc(BASE, livekitPackage, { failover });
   return rpc.request('RoomService', 'CreateRoom', {}, {
     authorization: 'Bearer test-token',
     ...directives,
@@ -72,7 +73,20 @@ const call = (directives: Record<string, string>, mode: FailoverConfig['mode'] =
     ).rejects.toThrow(TwirpError);
   });
 
-  it('does not fail over for a non-cloud host in auto mode', async () => {
-    await expect(call({ 'x-lk-mock-fail-regions': '0' }, 'auto')).rejects.toThrow(TwirpError);
+  it('does not fail over for a non-cloud host by default', async () => {
+    // No failover option => undefined => auto (cloud-only); 127.0.0.1 is not cloud.
+    const rpc = new TwirpRpc(BASE, livekitPackage);
+    await expect(
+      rpc.request('RoomService', 'CreateRoom', {}, {
+        authorization: 'Bearer test-token',
+        'x-lk-mock-fail-regions': '0',
+      }),
+    ).rejects.toThrow(TwirpError);
+  });
+
+  it('does not fail over when disabled with maxAttempts 1', async () => {
+    await expect(call({ 'x-lk-mock-fail-regions': '0' }, { maxAttempts: 1 })).rejects.toThrow(
+      TwirpError,
+    );
   });
 });

--- a/packages/livekit-server-sdk/test/api/failover.test.ts
+++ b/packages/livekit-server-sdk/test/api/failover.test.ts
@@ -11,7 +11,6 @@
 // tests drive TwirpRpc.request() directly because the public service methods do
 // not expose per-call headers.
 import { describe, expect, it } from 'vitest';
-import type { FailoverConfig } from '../../src/failover.js';
 import { TwirpError, TwirpRpc, livekitPackage } from '../../src/TwirpRPC.js';
 
 const BASE = process.env.LK_TEST_SERVER_URL ?? 'http://127.0.0.1:9999';
@@ -23,15 +22,17 @@ try {
   reachable = false;
 }
 
-// An explicit config enables failover on any host (the non-cloud mock) with a
-// tiny backoff so the tests run fast.
-const FORCED: FailoverConfig = { maxAttempts: 3, backoffBase: 1 };
-
+// failoverForce bypasses the cloud-host check (the mock is on 127.0.0.1) and a
+// tiny backoff keeps the tests fast — both are internal, test-only knobs.
 const call = (
   directives: Record<string, string>,
-  failover: FailoverConfig | undefined = FORCED,
+  { failover = true, force = true }: { failover?: boolean; force?: boolean } = {},
 ) => {
-  const rpc = new TwirpRpc(BASE, livekitPackage, { failover });
+  const rpc = new TwirpRpc(BASE, livekitPackage, {
+    failover,
+    failoverForce: force,
+    failoverBackoffMs: 1,
+  });
   return rpc.request('RoomService', 'CreateRoom', {}, {
     authorization: 'Bearer test-token',
     ...directives,
@@ -73,19 +74,15 @@ const call = (
     ).rejects.toThrow(TwirpError);
   });
 
-  it('does not fail over for a non-cloud host by default', async () => {
-    // No failover option => undefined => auto (cloud-only); 127.0.0.1 is not cloud.
-    const rpc = new TwirpRpc(BASE, livekitPackage);
-    await expect(
-      rpc.request('RoomService', 'CreateRoom', {}, {
-        authorization: 'Bearer test-token',
-        'x-lk-mock-fail-regions': '0',
-      }),
-    ).rejects.toThrow(TwirpError);
+  it('does not fail over for a non-cloud host (cloud-gated)', async () => {
+    // failover enabled but not forced; 127.0.0.1 is not a cloud host.
+    await expect(call({ 'x-lk-mock-fail-regions': '0' }, { force: false })).rejects.toThrow(
+      TwirpError,
+    );
   });
 
-  it('does not fail over when disabled with maxAttempts 1', async () => {
-    await expect(call({ 'x-lk-mock-fail-regions': '0' }, { maxAttempts: 1 })).rejects.toThrow(
+  it('does not fail over when disabled', async () => {
+    await expect(call({ 'x-lk-mock-fail-regions': '0' }, { failover: false })).rejects.toThrow(
       TwirpError,
     );
   });

--- a/packages/livekit-server-sdk/test/api/failover.test.ts
+++ b/packages/livekit-server-sdk/test/api/failover.test.ts
@@ -35,6 +35,8 @@ const call = (
   });
   return rpc.request('RoomService', 'CreateRoom', {}, {
     authorization: 'Bearer test-token',
+    // These tests exercise failover, not authz; skip the mock's permission check.
+    'x-lk-mock-skip-auth': 'true',
     ...directives,
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,9 +249,6 @@ importers:
       '@livekit/protocol':
         specifier: ^1.46.6
         version: 1.46.6
-      camelcase-keys:
-        specifier: ^9.0.0
-        version: 9.1.3
       jose:
         specifier: ^5.1.2
         version: 5.9.6
@@ -1840,14 +1837,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-keys@9.1.3:
-    resolution: {integrity: sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==}
-    engines: {node: '>=16'}
-
-  camelcase@8.0.0:
-    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
-    engines: {node: '>=16'}
-
   caniuse-lite@1.0.30001629:
     resolution: {integrity: sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==}
 
@@ -2796,10 +2785,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  map-obj@5.0.0:
-    resolution: {integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
@@ -3139,10 +3124,6 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-
-  quick-lru@6.1.2:
-    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
-    engines: {node: '>=12'}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -3540,10 +3521,6 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
-
-  type-fest@4.20.0:
-    resolution: {integrity: sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==}
-    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5230,15 +5207,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-keys@9.1.3:
-    dependencies:
-      camelcase: 8.0.0
-      map-obj: 5.0.0
-      quick-lru: 6.1.2
-      type-fest: 4.20.0
-
-  camelcase@8.0.0: {}
-
   caniuse-lite@1.0.30001629: {}
 
   chai@6.2.2: {}
@@ -6362,8 +6330,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  map-obj@5.0.0: {}
-
   markdown-it@14.1.0:
     dependencies:
       argparse: 2.0.1
@@ -6694,8 +6660,6 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
-
-  quick-lru@6.1.2: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -7181,8 +7145,6 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
-
-  type-fest@4.20.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
retries in alternative datacenters on 5xx and transport failures

also removed legacy camel-case, which was not needed since we switched to protobuf-es