### PR TITLE
fix: AudioSource.waitForPlayout resolving early with audio still queued

### DIFF
--- a/.changeset/tidy-lions-repair.md
+++ b/.changeset/tidy-lions-repair.md
@@ -1,0 +1,5 @@
+---
+'@livekit/rtc-node': patch
+---
+
+Fix AudioSource.waitForPlayout resolving immediately with audio still queued. The internal playout promise could be left resolved ("latched") by the drain timer firing during a gap between captures, or by clearQueue()/pause; a later waitForPlayout() then consumed the stale resolution and reported playout complete ~queueSizeMs early, clipping the tail of agent speech on every turn in downstream consumers.

--- a/.changeset/tidy-lions-repair.md
+++ b/.changeset/tidy-lions-repair.md
@@ -2,4 +2,4 @@
 '@livekit/rtc-node': patch
 ---
 
-Fix AudioSource.waitForPlayout resolving immediately with audio still queued. The internal playout promise could be left resolved ("latched") by the drain timer firing during a gap between captures, or by clearQueue()/pause; a later waitForPlayout() then consumed the stale resolution and reported playout complete ~queueSizeMs early, clipping the tail of agent speech on every turn in downstream consumers.
+Fix AudioSource.waitForPlayout resolving immediately with audio still queued. The internal playout promise could be left resolved ("latched") by the drain timer firing during a gap between captures, or by clearQueue()/pause; a later waitForPlayout() then consumed the stale resolution and reported playout complete ~queueSizeMs early, clipping the tail of agent speech on every turn in downstream consumers. The waiter is now discarded when released and lazily re-created on the next captureFrame, mirroring python-sdks. As part of this, waitForPlayout() now resolves immediately when no audio is queued instead of blocking until the next release.

--- a/packages/livekit-rtc/src/audio_source.test.ts
+++ b/packages/livekit-rtc/src/audio_source.test.ts
@@ -69,6 +69,19 @@ describe('AudioSource', () => {
     await source.close();
   });
 
+  it('waitForPlayout resolves immediately when no audio is queued', async () => {
+    const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
+    // nothing ever captured
+    const before = Date.now();
+    await source.waitForPlayout();
+    // fully drained (drain timer fired and released the waiter)
+    await pushAudio(source, 100);
+    await sleep(QUEUE_MS + 100);
+    await source.waitForPlayout();
+    expect(Date.now() - before).toBeLessThan(QUEUE_MS + 400);
+    await source.close();
+  });
+
   it('close resolves a pending waitForPlayout', async () => {
     const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
     await pushAudio(source, 600);

--- a/packages/livekit-rtc/src/audio_source.test.ts
+++ b/packages/livekit-rtc/src/audio_source.test.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { AudioFrame } from './audio_frame.js';
+import { AudioSource } from './audio_source.js';
+
+const SAMPLE_RATE = 24000;
+const FRAME_MS = 20;
+const SAMPLES = (SAMPLE_RATE * FRAME_MS) / 1000;
+const QUEUE_MS = 200;
+
+const makeFrame = () => new AudioFrame(new Int16Array(SAMPLES).fill(1000), SAMPLE_RATE, 1, SAMPLES);
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function pushAudio(source: AudioSource, durationMs: number) {
+  for (let i = 0; i < durationMs / FRAME_MS; i++) {
+    await source.captureFrame(makeFrame());
+  }
+}
+
+describe('AudioSource', () => {
+  it('waitForPlayout waits for the queued audio to drain', async () => {
+    const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
+    await pushAudio(source, 600);
+    const pushedAt = Date.now();
+    await source.waitForPlayout();
+    // ~QUEUE_MS of audio is still buffered when the last capture returns
+    expect(Date.now() - pushedAt).toBeGreaterThanOrEqual(QUEUE_MS - 50);
+    await source.close();
+  });
+
+  it('waitForPlayout waits for drain after a capture gap fired the drain timer', async () => {
+    const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
+    // a single frame followed by a gap longer than its duration: the internal
+    // drain timer fires and resolves the playout promise while the segment is
+    // still streaming
+    await source.captureFrame(makeFrame());
+    await sleep(FRAME_MS * 3);
+    await pushAudio(source, 600);
+    const pushedAt = Date.now();
+    await source.waitForPlayout();
+    expect(Date.now() - pushedAt).toBeGreaterThanOrEqual(QUEUE_MS - 50);
+    await source.close();
+  });
+
+  it('waitForPlayout waits for drain after a previous clearQueue', async () => {
+    const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
+    // e.g. an interrupted turn: buffered audio is dropped, releasing the
+    // playout promise
+    await source.captureFrame(makeFrame());
+    source.clearQueue();
+    // the next turn must not consume the stale resolution
+    await pushAudio(source, 600);
+    const pushedAt = Date.now();
+    await source.waitForPlayout();
+    expect(Date.now() - pushedAt).toBeGreaterThanOrEqual(QUEUE_MS - 50);
+    await source.close();
+  });
+
+  it('waitForPlayout resolves promptly when interrupted by clearQueue', async () => {
+    const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
+    await pushAudio(source, 600);
+    const playout = source.waitForPlayout();
+    source.clearQueue();
+    const clearedAt = Date.now();
+    await playout;
+    expect(Date.now() - clearedAt).toBeLessThan(50);
+    await source.close();
+  });
+
+  it('close resolves a pending waitForPlayout', async () => {
+    const source = new AudioSource(SAMPLE_RATE, 1, QUEUE_MS);
+    await pushAudio(source, 600);
+    const playout = source.waitForPlayout();
+    await source.close();
+    await playout;
+  });
+});

--- a/packages/livekit-rtc/src/audio_source.ts
+++ b/packages/livekit-rtc/src/audio_source.ts
@@ -28,10 +28,9 @@ export class AudioSource {
   /** @internal */
   currentQueueSize: number;
   /** @internal */
-  release = () => {};
+  promise?: Promise<void> = undefined;
   /** @internal */
-  released = false;
-  promise = this.newPromise();
+  resolvePromise?: () => void = undefined;
   /** @internal */
   timeout?: ReturnType<typeof setTimeout> = undefined;
   /** @internal */
@@ -86,32 +85,41 @@ export class AudioSource {
       },
     });
 
+    this.releaseWaiter();
+  }
+
+  /**
+   * Resolve the pending waitForPlayout() promise (if any) and reset the queue
+   * bookkeeping. Mirrors python-sdks' AudioSource._release_waiter: the promise is
+   * discarded here and lazily re-created by the next captureFrame, so a later
+   * waitForPlayout() can never consume a stale resolution and report playout
+   * complete while audio is still queued.
+   * @internal
+   */
+  releaseWaiter = () => {
+    if (!this.promise) {
+      return;
+    }
+
+    this.resolvePromise?.();
+    this.lastCapture = 0;
     this.currentQueueSize = 0;
-    this.release();
-  }
-
-  /** @internal */
-  async newPromise() {
-    this.released = false;
-    return new Promise<void>((resolve) => {
-      this.release = () => {
-        this.released = true;
-        resolve();
-      };
-    });
-  }
-
-  async waitForPlayout() {
-    const promise = this.promise;
-    await promise;
-    // Skip the reset if captureFrame re-armed the promise while we were waiting:
-    // the bookkeeping now belongs to audio captured after this playout completed.
-    if (this.promise === promise) {
-      this.lastCapture = 0;
-      this.currentQueueSize = 0;
-      this.promise = this.newPromise();
+    this.promise = undefined;
+    this.resolvePromise = undefined;
+    // cancel the drain timer (e.g. when released early by clearQueue), otherwise
+    // it would fire later and release the waiter of a subsequent segment
+    if (this.timeout) {
+      clearTimeout(this.timeout);
       this.timeout = undefined;
     }
+  };
+
+  async waitForPlayout() {
+    if (!this.promise) {
+      return;
+    }
+
+    await this.promise;
   }
 
   async captureFrame(frame: AudioFrame) {
@@ -134,15 +142,13 @@ export class AudioSource {
       clearTimeout(this.timeout);
     }
 
-    if (this.released) {
-      // The playout promise was already resolved — the drain timer fired during a
-      // gap between captures, or clearQueue() released it. Re-arm it so a later
-      // waitForPlayout() waits for this new audio instead of consuming the stale
-      // resolution and reporting playout complete while audio is still queued.
-      this.promise = this.newPromise();
+    if (!this.promise) {
+      this.promise = new Promise<void>((resolve) => {
+        this.resolvePromise = resolve;
+      });
     }
 
-    this.timeout = setTimeout(this.release, this.currentQueueSize);
+    this.timeout = setTimeout(this.releaseWaiter, this.currentQueueSize);
 
     const req = new CaptureAudioFrameRequest({
       sourceHandle: this.ffiHandle.handle,
@@ -170,7 +176,7 @@ export class AudioSource {
       this.timeout = undefined;
     }
     // Resolve any pending waitForPlayout() promise so callers don't hang.
-    this.release();
+    this.releaseWaiter();
     this.ffiHandle.dispose();
     this.closed = true;
   }

--- a/packages/livekit-rtc/src/audio_source.ts
+++ b/packages/livekit-rtc/src/audio_source.ts
@@ -29,6 +29,8 @@ export class AudioSource {
   currentQueueSize: number;
   /** @internal */
   release = () => {};
+  /** @internal */
+  released = false;
   promise = this.newPromise();
   /** @internal */
   timeout?: ReturnType<typeof setTimeout> = undefined;
@@ -90,18 +92,26 @@ export class AudioSource {
 
   /** @internal */
   async newPromise() {
+    this.released = false;
     return new Promise<void>((resolve) => {
-      this.release = resolve;
+      this.release = () => {
+        this.released = true;
+        resolve();
+      };
     });
   }
 
   async waitForPlayout() {
-    return this.promise.then(() => {
+    const promise = this.promise;
+    await promise;
+    // Skip the reset if captureFrame re-armed the promise while we were waiting:
+    // the bookkeeping now belongs to audio captured after this playout completed.
+    if (this.promise === promise) {
       this.lastCapture = 0;
       this.currentQueueSize = 0;
       this.promise = this.newPromise();
       this.timeout = undefined;
-    });
+    }
   }
 
   async captureFrame(frame: AudioFrame) {
@@ -122,6 +132,14 @@ export class AudioSource {
 
     if (this.timeout) {
       clearTimeout(this.timeout);
+    }
+
+    if (this.released) {
+      // The playout promise was already resolved — the drain timer fired during a
+      // gap between captures, or clearQueue() released it. Re-arm it so a later
+      // waitForPlayout() waits for this new audio instead of consuming the stale
+      // resolution and reporting playout complete while audio is still queued.
+      this.promise = this.newPromise();
     }
 
     this.timeout = setTimeout(this.release, this.currentQueueSize);


### PR DESCRIPTION
**Bug:** `AudioSource`'s playout promise is resolved by a drain timer re-armed on each `captureFrame`, but the promise is only replaced inside `waitForPlayout()`. Two paths leave it latched-resolved while audio is still streaming: the timer firing during a capture gap longer than the current queue estimate (common at TTS segment start), and `clearQueue()` (called by agents' output `pause()`, so every pause pre-latches the next turn). A later `waitForPlayout()` then resolves immediately with up to `queueSizeMs` (default 1000ms) still buffered.

**Impact:** in agents-js this fires `playbackFinished` ~1s early on every affected turn: the recorder truncates ~1s of agent speech from session recordings, `agent_speaking` spans under-report, and a pause/handoff right after the turn drops the still-queued tail at the speaker (root cause of "agent speech cut off at the tail without interruption").

**Fix:** mirror python-sdks, which hit and fixed this same bug in livekit/python-sdks#270 (\"fix wait_for_playout finishing too early\"): the waiter is discarded when released (drain timer, `clearQueue()`, `close()`) and lazily re-created by the next `captureFrame`, so a stale resolution can never be consumed. Releasing also cancels the drain timer so an orphaned timer can't release a later segment's waiter. One behavior change: `waitForPlayout()` now resolves immediately when no audio is queued instead of blocking until the next release, matching Python.

Both regression tests fail on the unfixed code and pass with the fix; verified end-to-end against agents-js's recorder pipeline (previously ~1s clip per turn, now 0ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

